### PR TITLE
Add redirect fields, canonical endpoint field, and rework HTTP probing logic

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 *.csv
 todo.txt
 *.json
+*.sqlite
 
 .cache/
 

--- a/models.py
+++ b/models.py
@@ -36,8 +36,17 @@ class Endpoint:
         self.status = None
         self.live = None
         self.redirect = None
+
+        # If an endpoint redirects, characterize the redirect behavior
         self.redirect_immediately_to = None
+        self.redirect_immediately_to_www = None
+        self.redirect_immediately_to_https = None
+        self.redirect_immediately_to_external = None
+        self.redirect_immediately_to_subdomain = None
         self.redirect_eventually_to = None
+        self.redirect_eventually_to_https = None
+        self.redirect_eventually_to_external = None
+        self.redirect_eventually_to_subdomain = None
 
         # Only HTTPS endpoints have these.
         # Initialize all of them to None, so that it's
@@ -69,7 +78,14 @@ class Endpoint:
             'live': self.live,
             'redirect': self.redirect,
             'redirect_eventually_to': self.redirect_eventually_to,
-            'redirect_immediately_to': self.redirect_immediately_to
+            'redirect_immediately_to': self.redirect_immediately_to,
+            'redirect_immediately_to_www': self.redirect_immediately_to_www,
+            'redirect_immediately_to_https': self.redirect_immediately_to_https,
+            'redirect_immediately_to_external': self.redirect_immediately_to_external,
+            'redirect_immediately_to_subdomain': self.redirect_immediately_to_subdomain,
+            'redirect_eventually_to_https': self.redirect_eventually_to_https,
+            'redirect_eventually_to_external': self.redirect_eventually_to_external,
+            'redirect_eventually_to_subdomain': self.redirect_eventually_to_subdomain
         }
 
         if self.protocol == "https":

--- a/models.py
+++ b/models.py
@@ -34,8 +34,8 @@ class Endpoint:
         # all HTTP/HTTPS endpoints have these
         self.headers = {}
         self.status = None
-        self.live = False
-        self.redirect = False
+        self.live = None
+        self.redirect = None
         self.redirect_immediately_to = None
         self.redirect_eventually_to = None
 

--- a/models.py
+++ b/models.py
@@ -37,7 +37,7 @@ class Endpoint:
         self.live = False
         self.redirect = False
         self.redirect_immediately_to = None
-        self.redirect_to = None
+        self.redirect_eventually_to = None
 
         # Only HTTPS endpoints have these.
         # Initialize all of them to None, so that it's
@@ -68,7 +68,7 @@ class Endpoint:
             'status': self.status,
             'live': self.live,
             'redirect': self.redirect,
-            'redirect_to': self.redirect_to,
+            'redirect_eventually_to': self.redirect_eventually_to,
             'redirect_immediately_to': self.redirect_immediately_to
         }
 

--- a/pshtt.py
+++ b/pshtt.py
@@ -141,47 +141,9 @@ def basic_check(endpoint):
 
     # The endpoint is live but there is a bad cert
     except requests.exceptions.SSLError:
-        # TODO: this is too broad, won't always be chain error.
         endpoint.https_bad_chain = True
         endpoint.live = True
-        # If there is a bad cert and the domain is not an https endpoint it is a redirect
-        if endpoint.protocol == "http":
-            endpoint.redirect = True
-    # Endpoint is not live
-    # TODO: Too broad, shouldn't swallow all errors.
-    # except:
-    #     logging.debug("Endpoint is not live: %s" % endpoint.url)
-    #     pass
 
-
-def https_check(endpoint):
-    logging.debug("sslyzing %s..." % endpoint.url)
-
-    # Use sslyze to check for HSTS and certificate errors
-    try:
-        # remove the https:// from prefix for sslyze
-        hostname = endpoint.url[8:]
-        server_info = ServerConnectivityInfo(hostname=hostname, port=443)
-        server_info.test_connectivity_to_server()
-
-        # Call plugin directly
-        cert_plugin = CertificateInfoPlugin()
-        cert_plugin_result = cert_plugin.process_task(server_info, 'certinfo_basic')
-        # Parsing sslyze output for results by line
-        for i in cert_plugin_result.as_text():
-            # Check for cert expiration
-            if "Not After" in i:
-                expired_cert(i, endpoint)
-            # Check for Hostname validation
-            elif "Hostname Validation" in i:
-                bad_hostname(i, endpoint)
-            # Check if Cert is trusted based on CA Stores
-            elif "CA Store" in i:
-                bad_chain(i, endpoint)
-                break
-    except:
-        # No valid hsts
-        pass
 
 
 # Given an endpoint and its detected headers, extract and parse

--- a/pshtt.py
+++ b/pshtt.py
@@ -127,7 +127,7 @@ def basic_check(endpoint):
 
             # TODO: handle relative redirects (where Location header omits origin)
             endpoint.redirect_immediately_to = r.history[0].headers['Location']
-            endpoint.redirect_to = r.url
+            endpoint.redirect_eventually_to = r.url
         endpoint.live = True
 
         # Store original headers and status code.
@@ -232,14 +232,14 @@ def is_valid_https(http, httpwww, https, httpswww):
 # Domain defaults to https if http endpoint forwards to https
 def is_defaults_to_https(http, httpwww, https, httpswww):
     if http.redirect or httpwww.redirect:
-        return (http.redirect and (http.redirect_to[:5] == "https")) or (httpwww.redirect and (httpwww.redirect_to[:5] == "https"))
+        return (http.redirect and (http.redirect_eventually_to[:5] == "https")) or (httpwww.redirect and (httpwww.redirect_eventually_to[:5] == "https"))
     else:
         return False
 
 
 # Domain downgrades if https endpoint redirects to http
 def is_downgrades_https(http, httpwww, https, httpswww):
-    return (https.redirect and (https.redirect_to[:5] == "http:")) or (httpswww.redirect and (httpswww.redirect_to[:5] == "http:"))
+    return (https.redirect and (https.redirect_eventually_to[:5] == "http:")) or (httpswww.redirect and (httpswww.redirect_eventually_to[:5] == "http:"))
 
 
 # A domain strictly forces https if https is live and http is not,
@@ -247,11 +247,11 @@ def is_downgrades_https(http, httpwww, https, httpswww):
 def is_strictly_forces_https(http, httpwww, https, httpswww):
     if ((not http.live) and (not httpwww.live)) and (https.live or httpswww.live):
         return True
-    elif (http.redirect and (http.redirect_to[:5] == "https")) and (httpwww.redirect and (httpwww.redirect_to[:5] == "https")):
+    elif (http.redirect and (http.redirect_eventually_to[:5] == "https")) and (httpwww.redirect and (httpwww.redirect_eventually_to[:5] == "https")):
         return True
-    elif (http.redirect and (http.redirect_to[:5] == "https")) and (not httpwww.live):
+    elif (http.redirect and (http.redirect_eventually_to[:5] == "https")) and (not httpwww.live):
         return True
-    elif (httpwww.redirect and (httpwww.redirect_to[:5] == "https")) and (not http.live):
+    elif (httpwww.redirect and (httpwww.redirect_eventually_to[:5] == "https")) and (not http.live):
         return True
     else:
         return False


### PR DESCRIPTION
This does a few things:

* Adds some fields describing the nature of the immediate and eventual redirects: whether the redirects go to an `https://` URI, whether it goes to a `www` subdomain, whether the redirect leaves the hostname, and whether the redirect leaves the hostname's parent (registerable) domain.
* Adds a `Canonical URL` field to the CSV and JSON output, that is determined using a port of [the logic from site-inspector](https://github.com/benbalter/site-inspector/blob/erics-mode/lib/site-inspector.rb#L201-L305). This makes use of the extra redirect fields mentioned above.
* Changes the way that HTTP/HTTPS endpoints are inspected, by first hitting each endpoint with following redirects disabled. If a redirect is detected, the endpoint is pinged again with following redirects enabled, and then information about the eventual redirect is parsed. This creates some additional requests compared to the previous method, but greatly simplifies the logic, and allows the exception handling to be limited more tightly.
* If an HTTPS endpoint throws an `SSLError` upon hitting it, it's retried again with certificate verification turned off. If it then works, the TLS error is overlooked and the endpoint's behavior is processed and analyzed. If it still doesn't work, then it's assumed to be a protocol error or some other novel issue that is preventing the connection from being established, and the endpoint is labeled not live.
* When redirects are followed, they are followed with certificate validation turned off. This greatly reduces the risk of having a certificate error get thrown when following redirects starting from an `http:` endpoint. Detecting a certificate error there during that process isn't of any real value to us, as all we care about is the eventual redirect destination URI.
* This refactoring to HTTP probing logic also removes the generic `except:` that was swallowing all errors (even `Ctrl-C` interrupts).
* Unfortunately, I had to **disable requests caching** (the `--cache` option now does nothing) because of a bug in how `requests-cache` handles redirects and the `follow_redirects` and `verify` parameters. I've filed this bug here: https://github.com/reclosedev/requests-cache/issues/70 To re-enable caching, we'll either need to fix the bug in requests-cache, or route around it somehow by using another method of writing our own caching layer.