### PR TITLE
Comprehensive logic update

### DIFF
--- a/models.py
+++ b/models.py
@@ -41,10 +41,12 @@ class Endpoint:
         self.redirect_immediately_to = None
         self.redirect_immediately_to_www = None
         self.redirect_immediately_to_https = None
+        self.redirect_immediately_to_http = None
         self.redirect_immediately_to_external = None
         self.redirect_immediately_to_subdomain = None
         self.redirect_eventually_to = None
         self.redirect_eventually_to_https = None
+        self.redirect_eventually_to_http = None
         self.redirect_eventually_to_external = None
         self.redirect_eventually_to_subdomain = None
 
@@ -82,9 +84,11 @@ class Endpoint:
             'redirect_immediately_to': self.redirect_immediately_to,
             'redirect_immediately_to_www': self.redirect_immediately_to_www,
             'redirect_immediately_to_https': self.redirect_immediately_to_https,
+            'redirect_immediately_to_http': self.redirect_immediately_to_http,
             'redirect_immediately_to_external': self.redirect_immediately_to_external,
             'redirect_immediately_to_subdomain': self.redirect_immediately_to_subdomain,
             'redirect_eventually_to_https': self.redirect_eventually_to_https,
+            'redirect_eventually_to_http': self.redirect_eventually_to_http,
             'redirect_eventually_to_external': self.redirect_eventually_to_external,
             'redirect_eventually_to_subdomain': self.redirect_eventually_to_subdomain
         }

--- a/models.py
+++ b/models.py
@@ -27,7 +27,7 @@ class Endpoint:
     def __init__(self, protocol, host, base_domain):
         # Basic endpoint description
         self.protocol = protocol
-        self.host = host # "www" or "root"
+        self.host = host  # "www" or "root"
         self.base_domain = base_domain
         self.url = self.url_for(protocol, host, base_domain)
 

--- a/models.py
+++ b/models.py
@@ -27,7 +27,7 @@ class Endpoint:
     def __init__(self, protocol, host, base_domain):
         # Basic endpoint description
         self.protocol = protocol
-        self.host = host
+        self.host = host # "www" or "root"
         self.base_domain = base_domain
         self.url = self.url_for(protocol, host, base_domain)
 
@@ -51,6 +51,7 @@ class Endpoint:
         # Only HTTPS endpoints have these.
         # Initialize all of them to None, so that it's
         # discernible if they don't get explicitly set.
+        self.https_valid = None
         self.https_bad_chain = None
         self.https_bad_hostname = None
         self.https_expired_cert = None
@@ -89,6 +90,7 @@ class Endpoint:
         }
 
         if self.protocol == "https":
+            obj['https_valid'] = self.https_valid
             obj['https_bad_chain'] = self.https_bad_chain
             obj['https_bad_hostname'] = self.https_bad_hostname
             obj['https_expired_cert'] = self.https_expired_cert

--- a/pshtt.py
+++ b/pshtt.py
@@ -254,7 +254,12 @@ def hsts_check(endpoint):
 
     # Set max age to the string after max-age
     # TODO: make this more resilient to pathological HSTS headers.
-    temp = re.split(';\s?', header)
+
+    # handle multiple HSTS headers, requests comma-separates them
+    first_pass = re.split(',\s?', header)[0]
+
+    temp = re.split(';\s?', first_pass)
+    print(endpoint.headers)
     endpoint.hsts_max_age = int(temp[0][len("max-age="):])
 
     # check if hsts includes sub domains

--- a/pshtt.py
+++ b/pshtt.py
@@ -261,7 +261,9 @@ def hsts_check(endpoint):
 
     temp = re.split(';\s?', first_pass)
     print(endpoint.headers)
-    endpoint.hsts_max_age = int(temp[0][len("max-age="):])
+
+    if "max-age" in header.lower():
+        endpoint.hsts_max_age = int(temp[0][len("max-age="):])
 
     # check if hsts includes sub domains
     if 'includesubdomains' in header.lower():

--- a/pshtt.py
+++ b/pshtt.py
@@ -254,8 +254,8 @@ def hsts_check(endpoint):
 
     # Set max age to the string after max-age
     # TODO: make this more resilient to pathological HSTS headers.
-    temp = header.split()
-    endpoint.hsts_max_age = int(re.sub(";", "", temp[0][len("max-age="):]))
+    temp = re.split(';\s?', header)
+    endpoint.hsts_max_age = int(temp[0][len("max-age="):])
 
     # check if hsts includes sub domains
     if 'includesubdomains' in header.lower():

--- a/pshtt.py
+++ b/pshtt.py
@@ -17,6 +17,7 @@ try:
 except ImportError:
     import urlparse # Python 2
 
+import nassl
 from sslyze.server_connectivity import ServerConnectivityInfo
 from sslyze.plugins.certificate_info_plugin import CertificateInfoPlugin
 
@@ -280,7 +281,11 @@ def https_check(endpoint):
     server_info.test_connectivity_to_server()
 
     cert_plugin = CertificateInfoPlugin()
-    cert_plugin_result = cert_plugin.process_task(server_info, 'certinfo_basic')
+    try:
+        cert_plugin_result = cert_plugin.process_task(server_info, 'certinfo_basic')
+    except nassl._nassl.OpenSSLError:
+        logging.warn("Error sslyzing %s" % endpoint.url)
+        return
 
     # A certificate can have multiple issues.
     for msg in cert_plugin_result.as_text():

--- a/pshtt.py
+++ b/pshtt.py
@@ -258,7 +258,6 @@ def hsts_check(endpoint):
     first_pass = re.split(',\s?', header)[0]
 
     temp = re.split(';\s?', first_pass)
-    print(endpoint.headers)
 
     if "max-age" in header.lower():
         endpoint.hsts_max_age = int(temp[0][len("max-age="):])

--- a/pshtt.py
+++ b/pshtt.py
@@ -18,6 +18,7 @@ except ImportError:
     import urlparse # Python 2
 
 import nassl
+import sslyze
 from sslyze.server_connectivity import ServerConnectivityInfo
 from sslyze.plugins.certificate_info_plugin import CertificateInfoPlugin
 
@@ -278,13 +279,18 @@ def https_check(endpoint):
     # remove the https:// from prefix for sslyze
     hostname = endpoint.url[8:]
     server_info = ServerConnectivityInfo(hostname=hostname, port=443)
-    server_info.test_connectivity_to_server()
+
+    try:
+        server_info.test_connectivity_to_server()
+    except sslyze.server_connectivity.ServerConnectivityError:
+        logging.warn("Error in sslyze server connectivity check")
+        return
 
     cert_plugin = CertificateInfoPlugin()
     try:
         cert_plugin_result = cert_plugin.process_task(server_info, 'certinfo_basic')
     except nassl._nassl.OpenSSLError:
-        logging.warn("Error sslyzing %s" % endpoint.url)
+        logging.warn("Error in sslyze cert info plugin")
         return
 
     # A certificate can have multiple issues.

--- a/pshtt.py
+++ b/pshtt.py
@@ -148,15 +148,14 @@ def basic_check(endpoint):
             # If it's a protocol error or other, it's not live.
             endpoint.live = False
             return
+        except requests.exceptions.RequestException:
+            endpoint.live = False
+            logging.warn("Unexpected requests exception during retry.")
+            return
 
         # If it was a certificate error of any kind, it's live.
         # Figure out the error(s).
         https_check(endpoint)
-
-    # This needs to go last, as a parent error class.
-    except requests.exceptions.ConnectionError:
-        endpoint.live = False
-        return
 
     # And this is the parent of ConnectionError and other things.
     # For example, "too many redirects".

--- a/pshtt.py
+++ b/pshtt.py
@@ -88,9 +88,10 @@ def result_for(domain):
         'Downgrades HTTPS': is_downgrades_https(domain),
         'Strictly Forces HTTPS': is_strictly_forces_https(domain),
 
-        'HTTPS Bad Chain': is_bad_chain(domain.http, domain.httpwww, domain.https, domain.httpswww),
-        'HTTPS Bad Host Name': is_bad_hostname(domain.http, domain.httpwww, domain.https, domain.httpswww),
-        'Expired Cert': is_expired_cert(domain.http, domain.httpwww, domain.https, domain.httpswww),
+        'HTTPS Bad Chain': is_bad_chain(domain),
+        'HTTPS Bad Host Name': is_bad_hostname(domain),
+        'Expired Cert': is_expired_cert(domain),
+
         'HSTS': is_hsts(domain.http, domain.httpwww, domain.https, domain.httpswww),
         'HSTS Header': hsts_header(domain.http, domain.httpwww, domain.https, domain.httpswww),
         'HSTS Max Age': hsts_max_age(domain.http, domain.httpwww, domain.https, domain.httpswww),
@@ -520,13 +521,39 @@ def is_strictly_forces_https(domain):
 
 
 # Domain has a bad chain if either https endpoints contain a bad chain
-def is_bad_chain(http, httpwww, https, httpswww):
-    return https.https_bad_chain or httpswww.https_bad_chain
+def is_bad_chain(domain):
+    canonical, http, httpwww, https, httpswww = domain.canonical, domain.http, domain.httpwww, domain.https, domain.httpswww
+
+    if canonical.host == "www":
+        canonical_https = httpswww
+    else:
+        canonical_https = https
+
+    return canonical_https.https_bad_chain
 
 
 # Domain has a bad hostname if either https endpoint fails hostname validation
-def is_bad_hostname(http, httpwww, https, httpswww):
-    return https.https_bad_hostname or httpswww.https_bad_hostname
+def is_bad_hostname(domain):
+    canonical, http, httpwww, https, httpswww = domain.canonical, domain.http, domain.httpwww, domain.https, domain.httpswww
+
+    if canonical.host == "www":
+        canonical_https = httpswww
+    else:
+        canonical_https = https
+
+    return canonical_https.https_bad_hostname
+
+
+# Returns if the either https endpoint has an expired cert
+def is_expired_cert(domain):
+    canonical, http, httpwww, https, httpswww = domain.canonical, domain.http, domain.httpwww, domain.https, domain.httpswww
+
+    if canonical.host == "www":
+        canonical_https = httpswww
+    else:
+        canonical_https = https
+
+    return canonical_https.https_expired_cert
 
 
 # Domain has hsts ONLY if the https (and not the www subdomain) has strict transport in the header
@@ -561,11 +588,6 @@ def is_hsts_preload_ready(http, httpwww, https, httpswww):
 def is_hsts_preload(http, httpwww, https, httpswww):
     # Returns if https endpoint has preload in hsts header
     return https.hsts_preload
-
-
-def is_expired_cert(http, httpwww, https, httpswww):
-    # Returns if the either https endpoint has an expired cert
-    return https.https_expired_cert or httpswww.https_expired_cert
 
 
 def is_hsts_preloaded(domain):

--- a/pshtt.py
+++ b/pshtt.py
@@ -293,8 +293,14 @@ def https_check(endpoint):
         logging.warn("Error in sslyze cert info plugin")
         return
 
+    try:
+        cert_response = cert_plugin_result.as_text()
+    except TypeError:
+        logging.warn("sslyze exception parsing issuer, see https://github.com/nabla-c0d3/sslyze/issues/167")
+        return
+
     # A certificate can have multiple issues.
-    for msg in cert_plugin_result.as_text():
+    for msg in cert_response:
 
         # Check for certifcate expiration.
         if (


### PR DESCRIPTION
This ports over a fair amount of logic from site-inspector for making domain-wide judgments, using the "canonical URL" logic added in #9.

A number of decisions use the "canonical HTTPS endpoint", which is to say that if the "canonical URL" for a domain is `http://www.agency.gov`, then the "canonical HTTPS endpoint" is `https://www.agency.gov`. This is meant to evaluate the state of HTTPS as it relates to the domain's "intended" URL.

* A domain has "Valid HTTPS" if its canonical HTTPS endpoint is live and uses a valid certificate.
* A domain defaults to HTTPS if its canonical URL is HTTPS.
* A domain downgrades HTTPS if the canonical HTTPS endpoint immediately redirects to **any** HTTP URI.
* A domain strictly forces HTTPS if both of its HTTP endpoints are either down or immediately redirect to **any** HTTPS URI.
* A domain has a bad chain, bad hostname, or expired certificate if its canonical HTTPS endpoint has a bad chain, bad hostname, or expired certificate.
* A domain has HSTS enabled if its canonical HTTPS endpoint has HSTS enabled. 
* The HSTS header and max age for the domain are sourced from the canonical HTTPS endpoint's HSTS header.
* A domain has HSTS enabled for the entire domain if its **root** HTTPS endpoint has HSTS enabled and uses `includeSubDomains`.
* A domain is HSTS "preload ready" if its **root** HTTPS endpoint has HSTS enabled, a max-age of at least 18 weeks, and uses `includeSubDomains` and the `preload` flag.
* A domain is HSTS preloaded if its domain name appears in the Chrome preload list, regardless of what header is present on any endpoint.

I also made a few changes to the CSV fields:

* I renamed `HSTS All Subdomains` to `HSTS Entire Domain`, to be explicit that this is measuring whether or not the HSTS policy includes the entire zone. This field will ignore HSTS headers set on `www` subdomains, regardless of whether that subdomain is canonical.
* I renamed `Expired Certificate` to `HTTPS Expired Certificate`, to be consistent with `HTTPS Bad Chain` and `HTTPS Bad Host Name`.
* I removed `HSTS Preload`, which was a domain-level assessment of whether the `preload` flag is set. It was not published or used in `site-inspector` or `domain-scan`, and can be confusing, because sometimes sites use a `preload` flag without an `includeSubDomains` field, and we're not interested in treating those any differently from an HSTS header with neither flag.

This PR brings `pshtt` to what I hope is near-parity with `site-inspector`. There are still some outstanding issues:

* The HSTS parser is too informal and doesn't handle pathological headers. 
* The HSTS parser also doesn't factor in `max-age=0`, which is the mechanism in HSTS to **disable** HSTS for a domain. While not used frequently, this is in use in the `.gov` space.
* There's not as much resiliency to pathological data in general. I'm in the process of running this version of the code on every federal `.gov`, and will note where it crashes or returns invalid data in some way. 
* Many fields will return `null` instead of `false`, and should have their values set explicitly by the main code path. IMO, this is preferable to giving fields default values at the model level, as it makes it difficult to detect bugs and places in the code path that aren't being exercised that should be. This is not an urgent issue, as `domain-scan` and DHS' renderer can understand this and treat `null` the same as `false`, but for general use this should be made consistent and the result should never include `null`'s.

There are some potential outstanding bugs in site-inspector/Pulse logic that I'd like to tackle as well, but they are minor and are more worth tackling once this tool is in use in both environments, rather than move the goalposts before we have parity.