### PR TITLE
Bug fixing, obtain close parity with Pulse's existing scans

### DIFF
--- a/models.py
+++ b/models.py
@@ -32,7 +32,7 @@ class Endpoint:
         self.url = self.url_for(protocol, host, base_domain)
 
         # all HTTP/HTTPS endpoints have these
-        self.headers = {}
+        self.headers = {}  # will be replaced with a requests.structures.CaseInsensitiveDict
         self.status = None
         self.live = None
         self.redirect = None
@@ -76,7 +76,7 @@ class Endpoint:
     def to_object(self):
         obj = {
             'url': self.url,
-            'headers': self.headers,
+            'headers': dict(self.headers),
             'status': self.status,
             'live': self.live,
             'redirect': self.redirect,

--- a/pshtt.py
+++ b/pshtt.py
@@ -173,7 +173,7 @@ def basic_check(endpoint):
         return
 
     # Endpoint is live, analyze the response.
-    endpoint.headers = dict(req.headers)
+    endpoint.headers = req.headers
 
     endpoint.status = req.status_code
     if str(endpoint.status).startswith('3'):

--- a/pshtt.py
+++ b/pshtt.py
@@ -438,9 +438,6 @@ def canonical_endpoint(http, httpwww, https, httpswww):
     all_http_unused = http_unused(http) and http_unused(httpwww)
     at_least_one_http_upgrades = http_upgrades(http) or http_upgrades(httpwww)
 
-    print(http_upgrades(http))
-    print(http_upgrades(httpwww))
-
     is_https = (
         at_least_one_https_endpoint and
         all_http_unused and

--- a/pshtt.py
+++ b/pshtt.py
@@ -154,7 +154,7 @@ def basic_check(endpoint):
             return
         except requests.exceptions.RequestException:
             endpoint.live = False
-            logging.warn("Unexpected requests exception during retry.")
+            logging.warn("Unexpected requests exception during retry. Printing error:")
             logging.warn(utils.format_last_exception())
             return
 
@@ -307,6 +307,10 @@ def https_check(endpoint):
         logging.warn("sslyze exception parsing issuer, see https://github.com/nabla-c0d3/sslyze/issues/167")
         return
 
+    # Debugging
+    for msg in cert_response:
+        print(msg)
+
     # A certificate can have multiple issues.
     for msg in cert_response:
 
@@ -427,12 +431,15 @@ def canonical_endpoint(http, httpwww, https, httpswww):
     def http_upgrades(endpoint):
         return (
             endpoint.redirect_immediately_to_https and
-            (not http.redirect_immediately_to_external)
+            (not endpoint.redirect_immediately_to_external)
         )
 
     at_least_one_https_endpoint = https_used(https) or https_used(httpswww)
     all_http_unused = http_unused(http) and http_unused(httpwww)
     at_least_one_http_upgrades = http_upgrades(http) or http_upgrades(httpwww)
+
+    print(http_upgrades(http))
+    print(http_upgrades(httpwww))
 
     is_https = (
         at_least_one_https_endpoint and

--- a/pshtt.py
+++ b/pshtt.py
@@ -150,10 +150,12 @@ def basic_check(endpoint):
         except requests.exceptions.SSLError:
             # If it's a protocol error or other, it's not live.
             endpoint.live = False
+            logging.warn("Unexpected SSL protocol (or other) error during retry.")
             return
         except requests.exceptions.RequestException:
             endpoint.live = False
             logging.warn("Unexpected requests exception during retry.")
+            logging.warn(utils.format_last_exception())
             return
 
         # If it was a certificate error of any kind, it's live.

--- a/pshtt.py
+++ b/pshtt.py
@@ -117,7 +117,7 @@ def ping(url, allow_redirects=False, verify=True):
         verify=verify,
 
         # set by --user_agent
-        data={'User-Agent': USER_AGENT},
+        headers={'User-Agent': USER_AGENT},
 
         # set by --timeout
         timeout=TIMEOUT

--- a/pshtt.py
+++ b/pshtt.py
@@ -263,6 +263,10 @@ def hsts_check(endpoint):
     if "max-age" in header.lower():
         endpoint.hsts_max_age = int(temp[0][len("max-age="):])
 
+    if endpoint.hsts_max_age <= 0:
+        endpoint.hsts = False
+        return
+
     # check if hsts includes sub domains
     if 'includesubdomains' in header.lower():
         endpoint.hsts_all_subdomains = True

--- a/pshtt.py
+++ b/pshtt.py
@@ -310,7 +310,7 @@ def https_check(endpoint):
     # A certificate can have multiple issues.
     for msg in cert_response:
 
-        # Check for certifcate expiration.
+        # Check for certificate expiration.
         if (
             (("Mozilla NSS CA Store") in msg) and
             (("FAILED") in msg) and
@@ -319,10 +319,11 @@ def https_check(endpoint):
             endpoint.https_expired_cert = True
 
         # Check for whether there's a valid chain to Mozilla.
+        # Note: this will also catch expired certs, but this is okay.
         if (
             (("Mozilla NSS CA Store") in msg) and
             (("FAILED") in msg) and
-            (("unable to get local issuer certificate") in msg)
+            (("Certificate is NOT Trusted") in msg)
         ):
             endpoint.https_bad_chain = True
 

--- a/pshtt.py
+++ b/pshtt.py
@@ -37,7 +37,7 @@ TIMEOUT = 1
 # The fields we're collecting, will be keys in JSON and
 # column headers in CSV.
 HEADERS = [
-    "Domain", "Canonical URL", "Live", "Redirect",
+    "Domain", "Canonical URL", "Live", "Redirect", "Redirect To",
     "Valid HTTPS", "Defaults HTTPS", "Downgrades HTTPS", "Strictly Forces HTTPS",
     "HTTPS Bad Chain", "HTTPS Bad Host Name", "HTTPS Expired Cert",
     "HSTS", "HSTS Header", "HSTS Max Age", "HSTS Entire Domain",
@@ -82,6 +82,7 @@ def result_for(domain):
         'Canonical URL': domain.canonical.url,
         'Live': is_live(domain),
         'Redirect': is_redirect(domain),
+        'Redirect To': redirects_to(domain),
 
         'Valid HTTPS': is_valid_https(domain),
         'Defaults HTTPS': is_defaults_to_https(domain),
@@ -479,6 +480,16 @@ def is_redirect(domain):
             (not http.live) or
             http.status >= 400
         ))
+
+
+# If a domain is a "redirect domain", where does it redirect to?
+def redirects_to(domain):
+    canonical = domain.canonical
+
+    if is_redirect(domain):
+        return canonical.redirect_eventually_to
+    else:
+        return None
 
 
 # A domain has "valid HTTPS" if it responds on port 443 at its canonical

--- a/pshtt.py
+++ b/pshtt.py
@@ -157,6 +157,8 @@ def basic_check(endpoint):
             return
 
         # If it was a certificate error of any kind, it's live.
+        endpoint.live = True
+
         # Figure out the error(s).
         https_check(endpoint)
 

--- a/pshtt.py
+++ b/pshtt.py
@@ -247,6 +247,11 @@ def basic_check(endpoint):
 # Given an endpoint and its detected headers, extract and parse
 # any present HSTS header, decide what HSTS properties are there.
 def hsts_check(endpoint):
+    # Disqualify domains with a bad host, they won't work as valid HSTS.
+    if endpoint.https_bad_hostname:
+        endpoint.hsts = False
+        return
+
     header = endpoint.headers.get("Strict-Transport-Security")
 
     if header is None:

--- a/pshtt.py
+++ b/pshtt.py
@@ -308,8 +308,8 @@ def https_check(endpoint):
         return
 
     # Debugging
-    for msg in cert_response:
-        print(msg)
+    # for msg in cert_response:
+    #     print(msg)
 
     # A certificate can have multiple issues.
     for msg in cert_response:

--- a/pshtt.py
+++ b/pshtt.py
@@ -358,8 +358,10 @@ def canonical_endpoint(http, httpwww, https, httpswww):
     # or like:
     #   https:// -> 200, http:// -> http://www
 
+    at_least_one_www_used = httpswww.live or httpwww.live
+
     is_www = (
-        (httpswww.live or httpwww.live) and (
+        at_least_one_www_used and (
             (
                 https.redirect or
                 (not https.live) or
@@ -411,24 +413,25 @@ def canonical_endpoint(http, httpwww, https, httpswww):
     # It allows a site to be canonically HTTPS if the cert has
     # a valid hostname but invalid chain issues.
 
-    def endpoint_used(endpoint):
+    def https_used(endpoint):
         return endpoint.live and (not endpoint.https_bad_hostname)
 
-    def endpoint_unused(endpoint):
-        return (endpoint.redirect or
+    def http_unused(endpoint):
+        return (
+            endpoint.redirect or
             (not endpoint.live) or
             (not str(endpoint.status).startswith("2"))
         )
 
-    def endpoint_upgrades(endpoint):
+    def http_upgrades(endpoint):
         return (
             endpoint.redirect_immediately_to_https and
             (not http.redirect_immediately_to_external)
         )
 
-    at_least_one_https_endpoint = endpoint_used(https) or endpoint_used(httpswww)
-    all_http_unused = endpoint_unused(http) and endpoint_unused(httpwww)
-    at_least_one_http_upgrades = endpoint_upgrades(http) or endpoint_upgrades(httpwww)
+    at_least_one_https_endpoint = https_used(https) or https_used(httpswww)
+    all_http_unused = http_unused(http) and http_unused(httpwww)
+    at_least_one_http_upgrades = http_upgrades(http) or http_upgrades(httpwww)
 
     is_https = (
         at_least_one_https_endpoint and
@@ -444,6 +447,7 @@ def canonical_endpoint(http, httpwww, https, httpswww):
         return https
     elif (not is_www) and (not is_https):
         return http
+
 
 ##
 # Judgment calls based on observed endpoint data.

--- a/pshtt.py
+++ b/pshtt.py
@@ -522,7 +522,7 @@ def is_defaults_to_https(domain):
 
 
 # Domain downgrades if HTTPS is supported in some way, but
-# its canonical HTTPS endpoint immediately redirects to HTTP.
+# its canonical HTTPS endpoint immediately redirects internally to HTTP.
 def is_downgrades_https(domain):
     canonical, https, httpswww = domain.canonical, domain.https, domain.httpswww
 
@@ -539,7 +539,11 @@ def is_downgrades_https(domain):
     else:
         canonical_https = https
 
-    return (supports_https and canonical_https.redirect_immediately_to_http)
+    return (
+        supports_https and
+        canonical_https.redirect_immediately_to_http and
+        (not canonical_https.redirect_immediately_to_external)
+    )
 
 
 # A domain "Strictly Forces HTTPS" if one of the HTTPS endpoints is

--- a/pshtt.py
+++ b/pshtt.py
@@ -38,7 +38,7 @@ TIMEOUT = 1
 # column headers in CSV.
 HEADERS = [
     "Domain", "Canonical URL", "Live", "Redirect", "Redirect To",
-    "Valid HTTPS", "Defaults HTTPS", "Downgrades HTTPS", "Strictly Forces HTTPS",
+    "Valid HTTPS", "Defaults to HTTPS", "Downgrades HTTPS", "Strictly Forces HTTPS",
     "HTTPS Bad Chain", "HTTPS Bad Host Name", "HTTPS Expired Cert",
     "HSTS", "HSTS Header", "HSTS Max Age", "HSTS Entire Domain",
     "HSTS Preload Ready", "HSTS Preloaded"
@@ -85,7 +85,7 @@ def result_for(domain):
         'Redirect To': redirects_to(domain),
 
         'Valid HTTPS': is_valid_https(domain),
-        'Defaults HTTPS': is_defaults_to_https(domain),
+        'Defaults to HTTPS': is_defaults_to_https(domain),
         'Downgrades HTTPS': is_downgrades_https(domain),
         'Strictly Forces HTTPS': is_strictly_forces_https(domain),
 

--- a/pshtt.py
+++ b/pshtt.py
@@ -261,8 +261,9 @@ def hsts_check(endpoint):
 
     # handle multiple HSTS headers, requests comma-separates them
     first_pass = re.split(',\s?', header)[0]
+    second_pass = re.sub('\'', '', first_pass)
 
-    temp = re.split(';\s?', first_pass)
+    temp = re.split(';\s?', second_pass)
 
     if "max-age" in header.lower():
         endpoint.hsts_max_age = int(temp[0][len("max-age="):])

--- a/pshtt.py
+++ b/pshtt.py
@@ -656,7 +656,7 @@ def is_hsts_entire_domain(domain):
 def is_hsts_preload_ready(domain):
     https = domain.https
 
-    eighteen_weeks = (https.hsts_max_age and (https.hsts_max_age >= 10886400))
+    eighteen_weeks = ((https.hsts_max_age is not None) and (https.hsts_max_age >= 10886400))
     preload_ready = (eighteen_weeks and https.hsts_all_subdomains and https.hsts_preload)
 
     return preload_ready

--- a/utils.py
+++ b/utils.py
@@ -4,7 +4,14 @@ import errno
 import csv
 import logging
 import datetime
+import sys
+import traceback
 
+
+# Display exception without re-throwing it.
+def format_last_exception():
+  exc_type, exc_value, exc_traceback = sys.exc_info()
+  return "\n".join(traceback.format_exception(exc_type, exc_value, exc_traceback))
 
 # mkdir -p in python, from:
 # http://stackoverflow.com/questions/600268/mkdir-p-functionality-in-python

--- a/utils.py
+++ b/utils.py
@@ -10,8 +10,9 @@ import traceback
 
 # Display exception without re-throwing it.
 def format_last_exception():
-  exc_type, exc_value, exc_traceback = sys.exc_info()
-  return "\n".join(traceback.format_exception(exc_type, exc_value, exc_traceback))
+    exc_type, exc_value, exc_traceback = sys.exc_info()
+    return "\n".join(traceback.format_exception(exc_type, exc_value, exc_traceback))
+
 
 # mkdir -p in python, from:
 # http://stackoverflow.com/questions/600268/mkdir-p-functionality-in-python


### PR DESCRIPTION
This PR brings `pshtt` into "close enough" parity with the existing scans that take on [Pulse](https://pulse.cio.gov), which currently use [`site-inspector`](https://github.com/benbalter/site-inspector) v1.0.2.

I'll comment inline on the PR with the changes that were made here. It was a lot of little paper cuts to fix regressions and mistakes that became obvious when comparing the output of `pshtt` and `site-inspector` on ~1,300 `.gov` domains. I used `domain-scan` (on [this open PR branch](https://github.com/18F/domain-scan/pull/76) to orchestrate `pshtt` and `site-inspector` in tandem and then compared the delta between the two in a spreadsheet viewer.

One notable change:

* I added a `Redirect To` field, for parity with the current output of domain-scan's `inspect` scanner, which for "redirect domains" (domains where `Redirect` is true) contains the destination the domain redirects to.

I plan to take the version of `pshtt` on this branch and integrate it into Pulse imminently, replacing the current `site-inspector` path.

cc @garrettr @gbinal