### PR TITLE
Fixes a x.509 parsing error

### DIFF
--- a/pshtt.py
+++ b/pshtt.py
@@ -306,6 +306,9 @@ def https_check(endpoint):
     except nassl._nassl.OpenSSLError:
         logging.warn("Error in sslyze cert info plugin")
         return
+    except nassl.x509_certificate.X509HostnameValidationError:
+        logging.warn("Error parsing x.509 certificate.")
+        return
 
     try:
         cert_response = cert_plugin_result.as_text()


### PR DESCRIPTION
This catches and handles a non-graceful error that `sslyze` throws when it finds a certificate with no valid SAN or common name field. 

I'd rather not catch these one by one, but there is [no overarching parent class](https://github.com/nabla-c0d3/nassl/blob/6d731c426da9a15597aec950cadadce0f0712b3f/nassl/x509_certificate.py#L10-L11), so not much of a choice.

This seems to affect only state/local .gov domains in the northeastern USA, suggesting that maybe there's a regional vendor with a malformed certificate problem that serves a large part of that market.