### PR TITLE
Create dockerfile to run pshtt in a container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,3 @@
+FROM python:2.7-onbuild
+
+ENTRYPOINT ["./entrypoint.sh"]

--- a/README.md
+++ b/README.md
@@ -11,6 +11,18 @@ Download the repository, then install all dependencies.
 pip install -r requirements.txt
 ```
 
+#### Using docker
+```bash
+docker build -t pshtt/cli .
+
+docker run --rm -it \
+  --name pshtt \
+  -v $(pwd):/data \
+  -e UID=1042 \           /* Change the ownership of the files (**e.g** results)
+  -e GID=1042 \           to the user with id 1042 and to the group with id 1042. */
+  pshtt/cli
+```
+
 #### Usage and examples
 ```bash
 ./pshtt_cli [options] DOMAIN...

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+
+if [ "$USER_ID" ]; then
+	uid="$USER_ID"
+else
+	cat >&2 <<-'EOINFO'
+	INFO: No uid as been specified, 1000 will be used by
+	default.
+	Use "-e USER_ID=1042" to set it in "docker run".
+	****************************************************
+	EOINFO
+
+	uid=1000
+fi
+
+if [ "$GROUP_ID" ]; then
+	gid="$GROUP_ID"
+else
+	cat >&2 <<-'EOINFO'
+	INFO: No gid as been specified, 1000 will be used by
+	default.
+	Use "-e GROUP_ID=1042" to set it in "docker run".
+	****************************************************
+	EOINFO
+
+	gid=1000
+fi
+
+# Copy the input if there is one in the mount point
+if [ -f /data/*.csv ]; then
+  cp /data/*.csv /usr/src/app
+fi
+
+./pshtt_cli $@
+
+# Copy the results back to the mount point and change the ownership so the host
+# gets it and can read it
+cp /usr/src/app/*.csv /data/
+chown -R "${uid}:${gid}" /data/


### PR DESCRIPTION
  * Basic dockerfile extending python:2.7-onbuild
  * Create custom entrypoint to change ownership of results file
  * Add a bit of documentation to the README
    - how to build the image
    - how to use it