### PR TITLE
Check if any CSVs exists before copy

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -35,5 +35,7 @@ python -m pshtt.cli $@
 
 # Copy the results back to the mount point and change the ownership so the host
 # gets it and can read it
-cp /usr/src/app/*.csv /data/
+if [ -f /usr/src/app/*.csv ]; then
+  cp /usr/src/app/*.scv /data/
+fi
 chown -R "${uid}:${gid}" /data/


### PR DESCRIPTION
If there are no CSVs present in the directory which is mounted to `/data` and if you do not provide and input to `pshtt` (e.g., if you only run `pshtt` or `pshtt -h` to find out about its functionality), then you will get the following error:
```
cp: cannot stat ‘/usr/src/app/*.csv’: No such file or directory
```
This change makes sure that the `cp` command is only executed if any CSVs are present.