### PR TITLE
Change UID and GID to USER_ID and GROUP_ID

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,8 +39,8 @@ docker build -t pshtt/cli .
 docker run --rm -it \
   --name pshtt \
   -v $(pwd):/data \
-  -e UID=1042 \           /* Change the ownership of the files (**e.g** results)
-  -e GID=1042 \           to the user with id 1042 and to the group with id 1042. */
+  -e USER_ID=1042 \           /* Change the ownership of the files (**e.g** results)
+  -e GROUP_ID=1042 \         to the user with id 1042 and to the group with id 1042. */
   pshtt/cli
 ```
 


### PR DESCRIPTION
According to https://github.com/dhs-ncats/pshtt/blob/1d3db29e69b5af5d8f6dfdb40a2ab4bbc9cac1c7/entrypoint.sh the environment variables should be USER_ID and GROUP_ID instead of UID and GID, so this change updates README.md with the correct instructions.