### PR TITLE
Preserve quotes when passing parameters to pshtt.cli

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -31,7 +31,7 @@ if [ -f /data/*.csv ]; then
   cp /data/*.csv /usr/src/app
 fi
 
-python -m pshtt.cli $@
+python -m pshtt.cli "$@"
 
 # Copy the results back to the mount point and change the ownership so the host
 # gets it and can read it


### PR DESCRIPTION
I stumbled upon this problem when trying to execute the following:
```
docker run --rm -it --name pshtt -v $(pwd):/data -e USER_ID=1042 -e GROUP_ID=1042 pshtt/cli rijksoverheid.nl --user-agent "github.com/18f/domain-scan, pshtt.py"
```
The result would be:
```
Failed to connect.
Failed to connect.
Failed to connect.
Failed to connect.
Wrote results to results.csv.
```
Further inspection showed that the failed connections were actually requests to `http://pshtt.py`. Why? Because without quotes Python's parameter parser only sees `--user-agent github.com/18f/domain-scan, pshtt.py`, so the space after `github.com/18f/domain-scan,` made `pshtt.py` seem like just another domain name to be checked.

Adding quotes around `$@` like so `python -m pshtt.cli "$@"` makes sure that the quotes in the parameters are maintained and thus fixes this problem.