### PR TITLE
Mark immediate external redirects as eventual redirects, when the eventual redirect fails

### DIFF
--- a/pshtt/cli.py
+++ b/pshtt/cli.py
@@ -68,5 +68,6 @@ def main():
         pshtt.csv_for(results, out_file)
         logging.warn("Wrote results to %s." % out_file)
 
+        
 if __name__ == '__main__':
     main()

--- a/pshtt/cli.py
+++ b/pshtt/cli.py
@@ -68,6 +68,6 @@ def main():
         pshtt.csv_for(results, out_file)
         logging.warn("Wrote results to %s." % out_file)
 
-        
+
 if __name__ == '__main__':
     main()

--- a/pshtt/pshtt.py
+++ b/pshtt/pshtt.py
@@ -250,7 +250,7 @@ def basic_check(endpoint):
             )
 
         # If we were able to make the first redirect, but not the ultimate redirect,
-        # and if the immediate redirect is external, then it's accurate enough to say
+        # and if the immediate redirect is external, then it's accurate enough to
         # say that the eventual redirect is the immediate redirect, since you're capturing
         # the domain it's going to.
         # This also avoids "punishing" the domain for configuration issues of the site

--- a/pshtt/pshtt.py
+++ b/pshtt/pshtt.py
@@ -249,6 +249,19 @@ def basic_check(endpoint):
                 (subdomain_original != subdomain_eventual)
             )
 
+        # If we were able to make the first redirect, but not the ultimate redirect,
+        # and if the immediate redirect is external, then it's accurate enough to say
+        # say that the eventual redirect is the immediate redirect, since you're capturing
+        # the domain it's going to.
+        # This also avoids "punishing" the domain for configuration issues of the site
+        # it redirects to.
+        elif endpoint.redirect_immediately_to_external:
+            endpoint.redirect_eventually_to = endpoint.redirect_immediately_to
+            endpoint.redirect_eventually_to_https = endpoint.redirect_immediately_to_https
+            endpoint.redirect_eventually_to_http = endpoint.redirect_immediately_to_http
+            endpoint.redirect_eventually_to_external = endpoint.redirect_immediately_to_external
+            endpoint.redirect_eventually_to_subdomain = endpoint.redirect_immediately_to_subdomain
+
 
 # Given an endpoint and its detected headers, extract and parse
 # any present HSTS header, decide what HSTS properties are there.


### PR DESCRIPTION
This is meant to address situations like https://github.com/18F/pulse/issues/596 that come from scans like this:

https://s3.amazonaws.com/pulse.cio.gov/archive/2016-11-11/cache/pshtt/fedrooms.gov.json

Where each endpoint says `redirect` is `true`, but the overall domain comes up with a `Redirect` of `false`.

This happens when fedrooms.gov redirects to a gsa.gov URI that then redirects to another gsa.gov URI that is super flaky. When the final redirect doesn't work, fedrooms.gov's `redirect_eventually_*` fields are left as `null`. 

The overall `Redirect` field, which is trying to measure whether the domain is holistically a "redirect domain", correctly depends on whether the site eventually redirects away to an external domain.

To better capture information when later redirects don't work, and to avoid "punishing" a redirect domain that successfully redirects out to a flakey website, this will copy the immediate redirect information into the eventual redirect information for a domain.

Thoughts? Reasonable decision?