### PR TITLE
Move policy decisions into pshtt

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ The following values are returned in `results.csv`:
 * `HSTS Preload Ready` - A domain is HSTS "preload ready" if its root HTTPS endpoint has HSTS enabled, has a max-age of at least 18 weeks, and uses the `includeSubDomains` and `preload` flag.
 * `HSTS Preloaded` - A domain is HSTS preloaded if its domain name appears in the [Chrome preload list](https://chromium.googlesource.com/chromium/src/net/+/master/http/transport_security_state_static.json), regardless of what header is present on any endpoint.
 * `Domain Supports HTTPS` - A domain 'Supports HTTPS' when it doesn't downgrade and has valid HTTPS, or when it doesn't downgrade and has a bad chain but not a bad hostname (a bad hostname makes it clear the domain isn't actively attempting to support HTTPS, whereas an incomplete chain is just a mistake.). Domains with a bad chain "support" HTTPS but user-side errors can be expected.
-* `Domain Enforces HTTPS` - A domain that 'Enforces HTTPS' must 'Support HTTPS' and default to HTTPS. 'Redirect domains' must strictly enforce HTTPS.
+* `Domain Enforces HTTPS` - A domain that 'Enforces HTTPS' must 'Support HTTPS' and default to HTTPS. For websites (where `Redirect` is `false`) they are allowed to _eventually_ redirect to an `https://` URI. For "redirect domains" (domains where the `Redirect` value is `true`) they must _immediately_ redirect clients to an `https://` URI (even if that URI is on another domain) in order to be said to enforce HTTPS.
 * `Domain Uses Strong HSTS` - A domain 'Uses Strong HSTS' when the max-age ≥ 31536000.
 
 ## Acknowledgements

--- a/README.md
+++ b/README.md
@@ -72,6 +72,9 @@ The following values are returned in `results.csv`:
 * `HSTS Entire Domain` - A domain has HSTS enabled for the entire domain if its root HTTPS endpoint has HSTS enabled and uses the HSTS `includeSubDomains` flag.
 * `HSTS Preload Ready` - A domain is HSTS "preload ready" if its root HTTPS endpoint has HSTS enabled, has a max-age of at least 18 weeks, and uses the `includeSubDomains` and `preload` flag.
 * `HSTS Preloaded` - A domain is HSTS preloaded if its domain name appears in the [Chrome preload list](https://chromium.googlesource.com/chromium/src/net/+/master/http/transport_security_state_static.json), regardless of what header is present on any endpoint.
+* `Domain Supports HTTPS` - A domain 'Supports HTTPS' when it doesn't downgrade and has valid HTTPS, or when it doesn't downgrade and has a bad chain but not a bad hostname (a bad hostname makes it clear the domain isn't actively attempting to support HTTPS, whereas an incomplete chain is just a mistake.). Domains with a bad chain "support" HTTPS but user-side errors can be expected.
+* `Domain Enforces HTTPS` - A domain that 'Enforces HTTPS' must 'Support HTTPS' and default to HTTPS. 'Redirect domains' must strictly enforce HTTPS.
+* `Domain Uses Strong HSTS` - A domain 'Uses Strong HSTS' when the max-age ≥ 31536000.
 
 ## Acknowledgements
 This code was modeled after [Ben Balter](https://github.com/benbalter)'s [site-inspector](https://github.com/benbalter/site-inspector), with significant guidance from [konklone](https://github.com/konklone).

--- a/pshtt/cli.py
+++ b/pshtt/cli.py
@@ -68,5 +68,6 @@ def main():
         pshtt.csv_for(results, out_file)
         logging.warn("Wrote results to %s." % out_file)
 
+
 if __name__ == '__main__':
     main()

--- a/pshtt/pshtt.py
+++ b/pshtt/pshtt.py
@@ -42,7 +42,7 @@ HEADERS = [
     "HTTPS Bad Chain", "HTTPS Bad Hostname", "HTTPS Expired Cert",
     "HSTS", "HSTS Header", "HSTS Max Age", "HSTS Entire Domain",
     "HSTS Preload Ready", "HSTS Preloaded",
-    "Uses HTTPS (M-15-13)", "Enforces HTTPS (M-15-13)", "HSTS (M-15-13)"
+    "Domain Supports HTTPS", "Domain Enforces HTTPS", "Domain Uses Strong HSTS"
 ]
 
 PRELOAD_CACHE = None
@@ -105,33 +105,36 @@ def result_for(domain):
         # A domain 'Uses HTTPS' when it doesn't downgrade and has valid HTTPS,
         # or when it doesn't downgrade and has a bad chain but not a bad hostname.
         # Domains with a bad chain "use" HTTPS but user-side errors should be expected.
-        'Uses HTTPS (M-15-13)': (
-            is_downgrades_https(domain) != True and
+        'Domain Supports HTTPS': (
+            (is_downgrades_https(domain) != True) and
             is_valid_https(domain)
         ) or (
-            is_downgrades_https(domain) != True and
+            (is_downgrades_https(domain) != True) and
             is_bad_chain(domain) and
-            is_bad_hostname(domain) != True
+            (is_bad_hostname(domain) != True)
         ),
         # A domain that 'Enforces HTTPS' must 'Use HTTPS' and default to HTTPS.
         # 'Redirect domains' must strictly enforce HTTPS.
-        'Enforces HTTPS (M-15-13)': ((
-            is_downgrades_https(domain) != True and
+        'Domain Enforces HTTPS': ((
+            (is_downgrades_https(domain) != True) and
             is_valid_https(domain)
         ) or (
-            is_downgrades_https(domain) != True and
+            (is_downgrades_https(domain) != True) and
             is_bad_chain(domain) and
-            is_bad_hostname(domain) != True
+            (is_bad_hostname(domain) != True)
         )) and (
             is_strictly_forces_https(domain) and (
                 is_defaults_to_https(domain) or
                 is_redirect(domain)
             ) or (
-                is_strictly_forces_https(domain) != True and
+                (is_strictly_forces_https(domain) != True) and
                 is_defaults_to_https(domain)
             )
         ),
-        'HSTS (M-15-13)': hsts_max_age(domain) >= 31536000
+        'Domain Uses Strong HSTS': (
+            is_hsts(domain) and
+            hsts_max_age(domain) >= 31536000
+        )
     }
 
     # But also capture the extended data for those who want it.

--- a/pshtt/pshtt.py
+++ b/pshtt/pshtt.py
@@ -113,7 +113,6 @@ def result_for(domain):
             is_bad_chain(domain) and
             is_bad_hostname(domain) != True
         ),
-
         # A domain that 'Enforces HTTPS' must 'Use HTTPS' and default to HTTPS.
         # 'Redirect domains' must strictly enforce HTTPS.
         'Enforces HTTPS (M-15-13)': ((

--- a/pshtt/pshtt.py
+++ b/pshtt/pshtt.py
@@ -112,27 +112,26 @@ def result_for(domain):
             is_downgrades_https(domain) != True and
             is_bad_chain(domain) and
             is_bad_hostname(domain) != True
-            ),
+        ),
 
         # A domain that 'Enforces HTTPS' must 'Use HTTPS' and default to HTTPS.
         # 'Redirect domains' must strictly enforce HTTPS.
         'Enforces HTTPS (M-15-13)': ((
             is_downgrades_https(domain) != True and
             is_valid_https(domain)
+        ) or (
+            is_downgrades_https(domain) != True and
+            is_bad_chain(domain) and
+            is_bad_hostname(domain) != True
+        )) and (
+            is_strictly_forces_https(domain) and (
+                is_defaults_to_https(domain) or
+                is_redirect(domain)
             ) or (
-                is_downgrades_https(domain) != True and
-                is_bad_chain(domain) and
-                is_bad_hostname(domain) != True
-                )
-            ) and (
-                is_strictly_forces_https(domain) and (
-                    is_defaults_to_https(domain) or
-                    is_redirect(domain)
-                    ) or (
-                        is_strictly_forces_https(domain) != True and
-                        is_defaults_to_https(domain)
-                        )
-                    ),
+                is_strictly_forces_https(domain) != True and
+                is_defaults_to_https(domain)
+            )
+        ),
         'HSTS (M-15-13)': hsts_max_age(domain) >= 31536000
     }
 

--- a/pshtt/pshtt.py
+++ b/pshtt/pshtt.py
@@ -102,7 +102,7 @@ def result_for(domain):
         'HSTS Preload Ready': is_hsts_preload_ready(domain),
         'HSTS Preloaded': is_hsts_preloaded(domain),
 
-        # A domain 'Uses HTTPS' when it doesn't downgrade and has valid HTTPS,
+        # A domain 'Support HTTPS' when it doesn't downgrade and has valid HTTPS,
         # or when it doesn't downgrade and has a bad chain but not a bad hostname.
         # Domains with a bad chain "use" HTTPS but user-side errors should be expected.
         'Domain Supports HTTPS': (
@@ -113,7 +113,7 @@ def result_for(domain):
             is_bad_chain(domain) and
             (is_bad_hostname(domain) != True)
         ),
-        # A domain that 'Enforces HTTPS' must 'Use HTTPS' and default to HTTPS.
+        # A domain that 'Enforces HTTPS' must 'Support HTTPS' and default to HTTPS.
         # 'Redirect domains' must strictly enforce HTTPS.
         'Domain Enforces HTTPS': ((
             (is_downgrades_https(domain) != True) and

--- a/pshtt/pshtt.py
+++ b/pshtt/pshtt.py
@@ -719,12 +719,13 @@ def is_domain_supports_https(domain):
 # enforce HTTPS.
 def is_domain_enforces_https(domain):
     return is_domain_supports_https(domain) and (
-        is_strictly_forces_https(domain) and (
+        is_strictly_forces_https(domain) and
+        (
             is_defaults_to_https(domain) or
             is_redirect(domain)
         ) or (
-            (is_strictly_forces_https(domain) != True) and
-            is_defaults_to_https(domain)
+        (is_strictly_forces_https(domain) != True) and
+        is_defaults_to_https(domain)
         )
     )
 

--- a/pshtt/pshtt.py
+++ b/pshtt/pshtt.py
@@ -102,9 +102,9 @@ def result_for(domain):
         'HSTS Preload Ready': is_hsts_preload_ready(domain),
         'HSTS Preloaded': is_hsts_preloaded(domain),
 
-        # A domain 'Support HTTPS' when it doesn't downgrade and has valid HTTPS,
+        # A domain 'Supports HTTPS' when it doesn't downgrade and has valid HTTPS,
         # or when it doesn't downgrade and has a bad chain but not a bad hostname.
-        # Domains with a bad chain "use" HTTPS but user-side errors should be expected.
+        # Domains with a bad chain "support" HTTPS but user-side errors should be expected.
         'Domain Supports HTTPS': (
             (is_downgrades_https(domain) != True) and
             is_valid_https(domain)

--- a/pshtt/pshtt.py
+++ b/pshtt/pshtt.py
@@ -41,7 +41,8 @@ HEADERS = [
     "Valid HTTPS", "Defaults to HTTPS", "Downgrades HTTPS", "Strictly Forces HTTPS",
     "HTTPS Bad Chain", "HTTPS Bad Hostname", "HTTPS Expired Cert",
     "HSTS", "HSTS Header", "HSTS Max Age", "HSTS Entire Domain",
-    "HSTS Preload Ready", "HSTS Preloaded"
+    "HSTS Preload Ready", "HSTS Preloaded",
+    "Uses HTTPS (M-15-13)", "Enforces HTTPS (M-15-13)", "HSTS (M-15-13)"
 ]
 
 PRELOAD_CACHE = None
@@ -99,7 +100,28 @@ def result_for(domain):
         'HSTS Max Age': hsts_max_age(domain),
         'HSTS Entire Domain': is_hsts_entire_domain(domain),
         'HSTS Preload Ready': is_hsts_preload_ready(domain),
-        'HSTS Preloaded': is_hsts_preloaded(domain)
+        'HSTS Preloaded': is_hsts_preloaded(domain),
+
+        'Uses HTTPS (M-15-13)': (
+            is_valid_https(domain) and
+            is_downgrades_https(domain) != False
+            ) or (
+                is_bad_chain(domain) == True and
+                is_bad_hostname(domain) == False
+            ),
+        'Enforces HTTPS (M-15-13)': (
+            is_valid_https(domain) and
+            is_downgrades_https(domain) != False
+            ) or (
+                is_bad_chain(domain) == True and
+                is_bad_hostname(domain) == False and (
+                    is_defaults_to_https(domain) or (
+                        is_redirect(domain) and
+                        is_strictly_forces_https(domain)
+                )
+            )
+        ),
+        'HSTS (M-15-13)': hsts_max_age(domain) >= 31536000
     }
 
     # But also capture the extended data for those who want it.

--- a/pshtt/pshtt.py
+++ b/pshtt/pshtt.py
@@ -702,13 +702,13 @@ def parent_domain_for(hostname):
 # Domains with a bad chain "support" HTTPS but user-side errors should be expected.
 def is_domain_supports_https(domain):
     return (
-            (is_downgrades_https(domain) != True) and
-            is_valid_https(domain)
-        ) or (
-            (is_downgrades_https(domain) != True) and
-            is_bad_chain(domain) and
-            (is_bad_hostname(domain) != True)
-        )
+        (not is_downgrades_https(domain)) and
+        is_valid_https(domain)
+    ) or (
+        (not is_downgrades_https(domain)) and
+        is_bad_chain(domain) and
+        (not is_bad_hostname(domain))
+    )
 
 
 # A domain that 'Enforces HTTPS' must 'Support HTTPS' and default to HTTPS.
@@ -724,8 +724,8 @@ def is_domain_enforces_https(domain):
             is_defaults_to_https(domain) or
             is_redirect(domain)
         ) or (
-        (is_strictly_forces_https(domain) != True) and
-        is_defaults_to_https(domain)
+            (not is_strictly_forces_https(domain)) and
+            is_defaults_to_https(domain)
         )
     )
 


### PR DESCRIPTION
This PR fixes Issue #29, adding three new fields to the tool output: 

- **Domain Supports HTTPS**: A domain 'Supports HTTPS' when it doesn't downgrade and has valid HTTPS, or when it doesn't downgrade and has a bad chain but not a bad hostname. This is an attempt to capture whether the domain owner intentionally supports HTTPS: a bad chain shows an intent (though a misconfiguration), while a bad hostname often means support is not intended.
- **Domain Enforces HTTPS**: A domain that 'Enforces HTTPS' must 'Support HTTPS' and default to HTTPS. 'Redirect domains' must also strictly enforce HTTPS.
- **Domain Uses Strong HSTS**: A domain 'Uses Strong HSTS' when max-age ≥ 31536000.

These definitions closely follow the contours of M-15-13 compliance, and also match what [Pulse](https://pulse.cio.gov/https/agencies/#q=homeland%20security) calls "Uses HTTPS", "Enforces HTTPS", and "Strict Transport Security (HSTS)".