### PR TITLE
Check whether a domain is formally pending HSTS preload (in queue)

### DIFF
--- a/pshtt/pshtt.py
+++ b/pshtt/pshtt.py
@@ -102,8 +102,8 @@ def result_for(domain):
         'HSTS Entire Domain': is_hsts_entire_domain(domain),
         'HSTS Preload Ready': is_hsts_preload_ready(domain),
         'HSTS Preload Pending': is_hsts_preload_pending(domain),
-        'HSTS Preloaded': is_hsts_preloaded(domain)
-      
+        'HSTS Preloaded': is_hsts_preloaded(domain),
+
         'Domain Supports HTTPS': is_domain_supports_https(domain),
         'Domain Enforces HTTPS': is_domain_enforces_https(domain),
         'Domain Uses Strong HSTS': is_domain_strong_hsts(domain)
@@ -718,7 +718,6 @@ def parent_domain_for(hostname):
     return str.join(".", hostname.split(".")[-2:])
 
 
-
 # A domain 'Supports HTTPS' when it doesn't downgrade and has valid HTTPS,
 # or when it doesn't downgrade and has a bad chain but not a bad hostname.
 # Domains with a bad chain "support" HTTPS but user-side errors should be expected.
@@ -757,9 +756,9 @@ def is_domain_strong_hsts(domain):
         is_hsts(domain) and
         hsts_max_age(domain) >= 31536000
     )
-  
-  
-  # Fetch the Chrome preload pending list. Don't cache, it's quick/small.
+
+
+# Fetch the Chrome preload pending list. Don't cache, it's quick/small.
 def fetch_preload_pending():
     logging.debug("Fetching Chrome pending preload list...")
 

--- a/pshtt/pshtt.py
+++ b/pshtt/pshtt.py
@@ -41,7 +41,7 @@ HEADERS = [
     "Valid HTTPS", "Defaults to HTTPS", "Downgrades HTTPS", "Strictly Forces HTTPS",
     "HTTPS Bad Chain", "HTTPS Bad Hostname", "HTTPS Expired Cert",
     "HSTS", "HSTS Header", "HSTS Max Age", "HSTS Entire Domain",
-    "HSTS Preload Ready", "HSTS Preload Pending", "HSTS Preloaded"
+    "HSTS Preload Ready", "HSTS Preload Pending", "HSTS Preloaded",
     "Domain Supports HTTPS", "Domain Enforces HTTPS", "Domain Uses Strong HSTS"
 ]
 

--- a/pshtt/pshtt.py
+++ b/pshtt/pshtt.py
@@ -41,12 +41,12 @@ HEADERS = [
     "Valid HTTPS", "Defaults to HTTPS", "Downgrades HTTPS", "Strictly Forces HTTPS",
     "HTTPS Bad Chain", "HTTPS Bad Hostname", "HTTPS Expired Cert",
     "HSTS", "HSTS Header", "HSTS Max Age", "HSTS Entire Domain",
-    "HSTS Preload Ready", "HSTS Preloaded"
+    "HSTS Preload Ready", "HSTS Preload Pending", "HSTS Preloaded"
 ]
 
 PRELOAD_CACHE = None
 preload_list = None
-
+preload_pending = None
 
 def inspect(base_domain):
     domain = Domain(base_domain)
@@ -99,6 +99,7 @@ def result_for(domain):
         'HSTS Max Age': hsts_max_age(domain),
         'HSTS Entire Domain': is_hsts_entire_domain(domain),
         'HSTS Preload Ready': is_hsts_preload_ready(domain),
+        'HSTS Preload Pending': is_hsts_preload_pending(domain),
         'HSTS Preloaded': is_hsts_preloaded(domain)
     }
 
@@ -693,17 +694,36 @@ def is_hsts_preload_ready(domain):
 
     return preload_ready
 
+# Whether a domain is formally pending inclusion
+# in Chrome's HSTS preload list.
+def is_hsts_preload_pending(domain):
+    return domain.domain in preload_pending
 
 # Whether a domain is contained in Chrome's HSTS preload list.
 def is_hsts_preloaded(domain):
     return domain.domain in preload_list
-
 
 # For "x.y.domain.gov", return "domain.gov".
 # TODO: use Public Suffix list to do this properly.
 def parent_domain_for(hostname):
     return str.join(".", hostname.split(".")[-2:])
 
+# Fetch the Chrome preload pending list. Don't cache, it's quick/small.
+def fetch_preload_pending():
+    logging.debug("Fetching Chrome pending preload list...")
+
+    pending_url = "https://hstspreload.appspot.com/api/v2/pending"
+
+    request = requests.get(pending_url)
+    raw = request.content
+    pending_json = json.loads(raw)
+
+    pending = []
+    for entry in pending_json:
+        if entry.get('include_subdomains', False) is True:
+            pending.append(entry['name'])
+
+    return pending
 
 def create_preload_list():
     preload_json = None
@@ -791,6 +811,10 @@ def inspect_domains(domains, options):
     # Download HSTS preload list, caches locally.
     global preload_list
     preload_list = create_preload_list()
+
+    # Download HSTS pending preload list. Not cached.
+    global preload_pending
+    preload_pending = fetch_preload_pending()
 
     # For every given domain, get inspect data.
     results = []

--- a/pshtt/pshtt.py
+++ b/pshtt/pshtt.py
@@ -48,6 +48,7 @@ PRELOAD_CACHE = None
 preload_list = None
 preload_pending = None
 
+
 def inspect(base_domain):
     domain = Domain(base_domain)
     domain.http = Endpoint("http", "root", base_domain)
@@ -694,19 +695,23 @@ def is_hsts_preload_ready(domain):
 
     return preload_ready
 
+
 # Whether a domain is formally pending inclusion
 # in Chrome's HSTS preload list.
 def is_hsts_preload_pending(domain):
     return domain.domain in preload_pending
 
+
 # Whether a domain is contained in Chrome's HSTS preload list.
 def is_hsts_preloaded(domain):
     return domain.domain in preload_list
+
 
 # For "x.y.domain.gov", return "domain.gov".
 # TODO: use Public Suffix list to do this properly.
 def parent_domain_for(hostname):
     return str.join(".", hostname.split(".")[-2:])
+
 
 # Fetch the Chrome preload pending list. Don't cache, it's quick/small.
 def fetch_preload_pending():
@@ -724,6 +729,7 @@ def fetch_preload_pending():
             pending.append(entry['name'])
 
     return pending
+
 
 def create_preload_list():
     preload_json = None


### PR DESCRIPTION
This adds a field, `HSTS Preload Pending`, which checks whether a domain is in the [HSTS preload queue](https://hstspreload.appspot.com/api/v2/pending).

Unfortunately, this does mean another HTTPS request made every time pshtt is run. It does this once already for the preload list itself. This is big enough to be cached on disk, but only if opted into with a flag, which I don't think anyone does right now.

For tools which orchestrate parallel uses of `pshtt`, like `domain-scan`, it might be helpful to have the orchestrator manage the downloading to disk of the preload list and pending list at the start of a bulk scan, and pass in their locations as flags so that `pshtt` don't have to re-download it every time during a bulk scan, but also don't rely on a cached version from a previous bulk scan.

What do you think? Should I add a cache flag for the pending list, like we do for the preload list? Is this field even worth capturing here at all?