### PR TITLE
When checking if www is canonical, measure "down" by 4XX and up

### DIFF
--- a/pshtt/pshtt.py
+++ b/pshtt/pshtt.py
@@ -412,7 +412,10 @@ def canonical_endpoint(http, httpwww, https, httpswww):
         return (
             (not endpoint.live) or
             endpoint.https_bad_hostname or
-            (not str(endpoint.status).startswith("2"))
+            (
+                (not str(endpoint.status).startswith("2")) and
+                (not str(endpoint.status).startswith("3"))
+            )
         )
 
     def goes_to_www(endpoint):


### PR DESCRIPTION
This PR is meant to fix situations like this one, where the `www` subdomain is seen as "canonical" even though it's just a redirect with an invalid cert:

https://s3.amazonaws.com/pulse.cio.gov/archive/2016-12-08/subdomains/scan/url/cache/pshtt/caution-www.usajobs.gov.json

In this case, `caution-www.usajobs.gov` is an OPM hostname that appears to be matching wildcard DNS. Both the root (`caution-www.usajobs.gov`) and the www subdomain (`www.caution-www.usajobs.gov`) resolve. 

The root has a valid cert and redirects eventually to `usajobs.gov`. The www subdomain has an invalid cert for that hostname and redirects eventually to `usajobs.gov`. This domain isn't considered a "redirect domain" because the redirects are all within the same parent domain. So, the root _should_ be marked as canonical here, but it was not.

The www subdomain was being marked as canonical because we were measuring whether the root endpoint was "down" just by looking at whether the response code is not 2XX. However, we should also exempt 3XX status codes from causing an endpoint to be considered "down". This is consistent with the intent of the logic behind measuring canonicality as documented in the comments, and shouldn't cause any regressions.
