### PR TITLE
Fix incorrect null results for "Downgrades HTTPS"

### DIFF
--- a/pshtt/pshtt.py
+++ b/pshtt/pshtt.py
@@ -588,11 +588,19 @@ def is_downgrades_https(domain):
     else:
         canonical_https = https
 
-    return (
-        supports_https and
-        canonical_https.redirect_immediately_to_http and
-        (not canonical_https.redirect_immediately_to_external)
-    )
+    # If the site doesn't support HTTPS, it doesn't make sense to ask if it
+    # downgrades it or not, so return None instead of True or False.
+    downgrades_https = None
+    if supports_https:
+        # Explicitly convert to bool to avoid unintentionally returning None,
+        # which may happen if the site doesn't redirect.
+        downgrades_https = bool(
+            canonical_https.redirect_immediately_to_http and
+            (not canonical_https.redirect_immediately_to_external)
+        )
+
+    return downgrades_https
+
 
 
 # A domain "Strictly Forces HTTPS" if one of the HTTPS endpoints is

--- a/pshtt/pshtt.py
+++ b/pshtt/pshtt.py
@@ -588,18 +588,13 @@ def is_downgrades_https(domain):
     else:
         canonical_https = https
 
-    # If the site doesn't support HTTPS, it doesn't make sense to ask if it
-    # downgrades it or not, so return None instead of True or False.
-    downgrades_https = None
-    if supports_https:
-        # Explicitly convert to bool to avoid unintentionally returning None,
-        # which may happen if the site doesn't redirect.
-        downgrades_https = bool(
-            canonical_https.redirect_immediately_to_http and
-            (not canonical_https.redirect_immediately_to_external)
-        )
-
-    return downgrades_https
+    # Explicitly convert to bool to avoid unintentionally returning None,
+    # which may happen if the site doesn't redirect.
+    return bool(
+        supports_https and
+        canonical_https.redirect_immediately_to_http and
+        (not canonical_https.redirect_immediately_to_external)
+    )
 
 
 

--- a/pshtt/pshtt.py
+++ b/pshtt/pshtt.py
@@ -597,7 +597,6 @@ def is_downgrades_https(domain):
     )
 
 
-
 # A domain "Strictly Forces HTTPS" if one of the HTTPS endpoints is
 # "live", and if both *HTTP* endpoints are either:
 #


### PR DESCRIPTION
This commit fixes 2 bugs with the logic for computing "Downgrades HTTPS":

1. If a site **does not** have HTTPS (`"Valid HTTPS": false"`), then
"Downgrades HTTPS" should be `null` because it doesn't make sense to ask if a
site downgrades HTTPS if it doesn't have HTTPS in the first place. Previously,
the code would return `false` in this case.

2. If a site **does** have HTTPS, there were some cases where the previous code
would incorrectly return `null` instead of `false`. Specifically, this would
happen if a site's domain name was also the canonical endpoint, in which case
the site does not redirect and all values related to redirects are None. Due to
Python's short-circuit evaluation of boolean expressions, this None value was
returned instead of the intended False from `is_downgrades_https`.

Fixes #49.