### PR TITLE
Added slant quotes to bash file existence check

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -27,7 +27,7 @@ else
 fi
 
 # Copy the input if there is one in the mount point
-if [ -f /data/*.csv ]; then
+if [ -f `/data/*.csv` ]; then
   cp /data/*.csv /usr/src/app
 fi
 
@@ -35,7 +35,7 @@ python -m pshtt.cli "$@"
 
 # Copy the results back to the mount point and change the ownership so the host
 # gets it and can read it
-if [ -f /usr/src/app/*.csv ]; then
+if [ -f `/usr/src/app/*.csv` ]; then
   cp /usr/src/app/*.csv /data/
 fi
 chown -R "${uid}:${gid}" /data/


### PR DESCRIPTION
I tend to put ISO 8601 dates into the filenames of various pshtt scans I run. The '-' characters escape the -f file existence check that occurs. Wrapping the search string in slant quotes resolves the issue. I have a more robust fix I'm working on that uses a find command, but this fixes, what was for me a vexing problem, relatively quickly.