### PR TITLE
Added missing runtime dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -59,6 +59,7 @@ setup(
         'wget>=3.2',
         'docopt',
         'requests_cache',
+        'pytablewriter',
     ],
 
     # Conveniently allows one to run the CLI tool as `pshtt`


### PR DESCRIPTION
Note, the version that I *know* works is 0.18.0.

To test / recreate, create a new virtual environment and:

```
$ cd pshtt/
$ pip install -e .
$ pshtt -h
Traceback (most recent call last):
  File "/Users/ianlee1521/.virtualenvs/pshtt/bin/pshtt", line 11, in <module>
    load_entry_point('pshtt', 'console_scripts', 'pshtt')()
  File "/Users/ianlee1521/.virtualenvs/pshtt/lib/python2.7/site-packages/pkg_resources/__init__.py", line 560, in load_entry_point
    return get_distribution(dist).load_entry_point(group, name)
  File "/Users/ianlee1521/.virtualenvs/pshtt/lib/python2.7/site-packages/pkg_resources/__init__.py", line 2648, in load_entry_point
    return ep.load()
  File "/Users/ianlee1521/.virtualenvs/pshtt/lib/python2.7/site-packages/pkg_resources/__init__.py", line 2302, in load
    return self.resolve()
  File "/Users/ianlee1521/.virtualenvs/pshtt/lib/python2.7/site-packages/pkg_resources/__init__.py", line 2308, in resolve
    module = __import__(self.module_name, fromlist=['__name__'], level=0)
  File "/Users/ianlee1521/projs/pshtt/pshtt/cli.py", line 27, in <module>
    import pshtt
  File "/Users/ianlee1521/projs/pshtt/pshtt/pshtt.py", line 12, in <module>
    import pytablewriter
ImportError: No module named pytablewriter

$ pip install pytablewriter
$ pshtt -h
pshtt ("pushed") is a tool to test domains for HTTPS best practices.
...
```