### PR TITLE
Update sslyze to 1.1.0

### DIFF
--- a/pshtt/pshtt.py
+++ b/pshtt/pshtt.py
@@ -16,7 +16,6 @@ try:
 except ImportError:
     import urlparse  # Python 2
 
-import nassl
 import sslyze
 import sslyze.synchronous_scanner
 
@@ -336,23 +335,13 @@ def https_check(endpoint):
     command = sslyze.plugins.certificate_info_plugin.CertificateInfoScanCommand()
     scanner = sslyze.synchronous_scanner.SynchronousScanner()
 
-    # try:
     cert_plugin_result = scanner.run_scan_command(server_info, command)
-    # except nassl._nassl.OpenSSLError as err:
-    #     logging.warn("Error in sslyze cert info plugin.")
-    #     logging.debug("{0}".format(err))
-    #     return
-    # except nassl.x509_certificate.X509HostnameValidationError as err:
-    #     logging.warn("Error parsing x.509 certificate.")
-    #     logging.debug("{0}".format(err))
-    #     return
 
     try:
         cert_response = cert_plugin_result.as_text()
-    except TypeError as err:
-        logging.warn("Error parsing malformed issuer field (see https://github.com/nabla-c0d3/sslyze/issues/167)")
-        logging.debug("{0}".format(err))
-        return
+    except AttributeError as err:
+        logging.warn("Known error in sslyze 1.X with EC public keys. See https://github.com/nabla-c0d3/sslyze/issues/215")
+        return None
 
     # Debugging
     # for msg in cert_response:

--- a/pshtt/pshtt.py
+++ b/pshtt/pshtt.py
@@ -18,8 +18,7 @@ except ImportError:
 
 import nassl
 import sslyze
-from sslyze.server_connectivity import ServerConnectivityInfo
-from sslyze.plugins.certificate_info_plugin import CertificateInfoPlugin
+import sslyze.synchronous_scanner
 
 from models import Domain, Endpoint
 
@@ -324,7 +323,7 @@ def https_check(endpoint):
 
     # remove the https:// from prefix for sslyze
     hostname = endpoint.url[8:]
-    server_info = ServerConnectivityInfo(hostname=hostname, port=443)
+    server_info = sslyze.server_connectivity.ServerConnectivityInfo(hostname=hostname, port=443)
 
     try:
         server_info.test_connectivity_to_server()
@@ -333,17 +332,20 @@ def https_check(endpoint):
         logging.debug("{0}".format(err))
         return
 
-    cert_plugin = CertificateInfoPlugin()
-    try:
-        cert_plugin_result = cert_plugin.process_task(server_info, 'certinfo_basic')
-    except nassl._nassl.OpenSSLError as err:
-        logging.warn("Error in sslyze cert info plugin.")
-        logging.debug("{0}".format(err))
-        return
-    except nassl.x509_certificate.X509HostnameValidationError as err:
-        logging.warn("Error parsing x.509 certificate.")
-        logging.debug("{0}".format(err))
-        return
+
+    command = sslyze.plugins.certificate_info_plugin.CertificateInfoScanCommand()
+    scanner = sslyze.synchronous_scanner.SynchronousScanner()
+
+    # try:
+    cert_plugin_result = scanner.run_scan_command(server_info, command)
+    # except nassl._nassl.OpenSSLError as err:
+    #     logging.warn("Error in sslyze cert info plugin.")
+    #     logging.debug("{0}".format(err))
+    #     return
+    # except nassl.x509_certificate.X509HostnameValidationError as err:
+    #     logging.warn("Error parsing x.509 certificate.")
+    #     logging.debug("{0}".format(err))
+    #     return
 
     try:
         cert_response = cert_plugin_result.as_text()

--- a/pshtt/pshtt.py
+++ b/pshtt/pshtt.py
@@ -331,7 +331,6 @@ def https_check(endpoint):
         logging.debug("{0}".format(err))
         return
 
-
     command = sslyze.plugins.certificate_info_plugin.CertificateInfoScanCommand()
     scanner = sslyze.synchronous_scanner.SynchronousScanner()
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
-requests==2.10.0
-SSLyze==0.13.6
+requests==2.13.0
+sslyze==1.1.0
 wget==3.2
 docopt
 requests_cache

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-requests==2.13.0
+requests==2.14.2
 sslyze==1.1.0
 wget==3.2
 docopt

--- a/setup.py
+++ b/setup.py
@@ -54,7 +54,7 @@ setup(
     packages=['pshtt'],
 
     install_requires=[
-        'requests>=2.10.0',
+        'requests>=2.14.2',
         'sslyze>=1.1.0',
         'wget>=3.2',
         'docopt',

--- a/setup.py
+++ b/setup.py
@@ -55,7 +55,7 @@ setup(
 
     install_requires=[
         'requests>=2.10.0',
-        'sslyze>=0.13.6',
+        'sslyze>=1.1.0',
         'wget>=3.2',
         'docopt',
         'requests_cache',


### PR DESCRIPTION
This updates `pshtt` to use `sslyze` 1.10: https://github.com/nabla-c0d3/sslyze/releases/tag/1.1.0

This version of sslyze supports Python 3, but this PR **does not update pshtt to Python 3 yet**. This is just to:

* change out the sslyze 0.X syntax to sslyze 1.X syntax (which is now considered stable as of 1.0)
* to remove handling for an outdated error that sslyze fixed 
* to add handling for a new error that sslyze has not yet fixed

It also updates the `requests` version to the latest version, to fix an issue I encountered between a separate dependency and that older version of `requests`.