### PR TITLE
Needs review: Python 3 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ sudo: false
 
 python:
   - '2.7'
+  - '3.5'
 
 install:
   - pip install flake8

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ sudo: false
 
 python:
   - '2.7'
+  - '3.4'
   - '3.5'
 
 install:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,3 @@
-FROM python:2.7-onbuild
+FROM python:3.5-onbuild
 
 ENTRYPOINT ["./entrypoint.sh"]

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 
 `pshtt` was developed to _push_ organizations— especially large ones like the US Federal Government :us: — to adopt HTTPS across the enterprise. Federal .gov domains must comply with [M-15-13](https://https.cio.gov), a 2015 memorandum from the White House Office of Management and Budget that requires federal agencies to enforce HTTPS on their web sites and services by the end of 2016. Much has been done, and [still more yet to do](https://18f.gsa.gov/2017/01/04/tracking-the-us-governments-progress-on-moving-https/).
 
-`pshtt` is a collaboration between the [Department of Homeland Security's National Cybersecurity Assessments and Technical Services (NCATS) team](https://github.com/dhs-ncats) and [the General Service Administration's 18F team](https://18f.gsa.gov), with contributions from NASA and various non-governmental organizations.
+`pshtt` is a collaboration between the [Department of Homeland Security's National Cybersecurity Assessments and Technical Services (NCATS) team](https://github.com/dhs-ncats) and [the General Service Administration's 18F team](https://18f.gsa.gov), with [contributions from NASA and various non-governmental organizations](https://github.com/dhs-ncats/pshtt/graphs/contributors).
 
 ## Getting Started
 

--- a/README.md
+++ b/README.md
@@ -3,12 +3,38 @@
 
 `pshtt` was developed to _push_ organizations— especially large ones like the US Federal Government :us: — to adopt HTTPS across the enterprise. Federal .gov domains must comply with [M-15-13](https://https.cio.gov), a 2015 memorandum from the White House Office of Management and Budget that requires federal agencies to enforce HTTPS on their web sites and services by the end of 2016. Much has been done, and [still more yet to do](https://18f.gsa.gov/2017/01/04/tracking-the-us-governments-progress-on-moving-https/).
 
-`pshtt` is a collaboration between GSA's 18F and the DHS National Cybersecurity Assessments and Technical Services team.
+`pshtt` is a collaboration between the [Department of Homeland Security's National Cybersecurity Assessments and Technical Services (NCATS) team](https://github.com/dhs-ncats) and [the General Service Administration's 18F team](https://18f.gsa.gov), with contributions from NASA and various non-governmental organizations.
 
 ## Getting Started
+
+`pshtt` can be installed as a module, or run directly from the repository.
+
+#### Installed as a module
+
 `pshtt` can be installed directly via pip:
+
 ```bash
 pip install pshtt
+```
+
+It can then be run directly:
+
+```bash
+pshtt example.com [options]
+```
+
+#### Running directly
+
+To run the tool locally from the repository, without installing , first install the requirements:
+
+```bash
+pip install -r requirements.txt
+```
+
+Then run it as a module via `python -m`:
+
+```bash
+python -m pshtt.cli example.com [options]
 ```
 
 #### Usage and examples

--- a/pshtt/cli.py
+++ b/pshtt/cli.py
@@ -23,9 +23,10 @@ Notes:
   CSV output will always be written to disk, defaulting to results.csv.
 """
 
+from . import pshtt
+from . import utils
+
 import docopt
-import pshtt
-import utils
 import logging
 import sys
 

--- a/pshtt/pshtt.py
+++ b/pshtt/pshtt.py
@@ -1,5 +1,8 @@
 #!/usr/bin/env python
 
+from . import utils
+from .models import Domain, Endpoint
+
 import requests
 # import requests_cache
 import re
@@ -7,7 +10,6 @@ import base64
 import json
 import csv
 import os
-import utils
 import logging
 import pytablewriter
 
@@ -18,8 +20,6 @@ except ImportError:
 
 import sslyze
 import sslyze.synchronous_scanner
-
-from models import Domain, Endpoint
 
 # We're going to be making requests with certificate validation disabled.
 requests.packages.urllib3.disable_warnings()
@@ -773,7 +773,8 @@ def fetch_preload_pending():
     pending_url = "https://hstspreload.org/api/v2/pending"
 
     request = requests.get(pending_url)
-    raw = request.content
+    raw = str(request.content, 'utf-8')
+
     pending_json = json.loads(raw)
 
     pending = []

--- a/pshtt/pshtt.py
+++ b/pshtt/pshtt.py
@@ -12,6 +12,7 @@ import csv
 import os
 import logging
 import pytablewriter
+import sys
 
 try:
     from urllib import parse as urlparse  # Python 3
@@ -773,7 +774,12 @@ def fetch_preload_pending():
     pending_url = "https://hstspreload.org/api/v2/pending"
 
     request = requests.get(pending_url)
-    raw = str(request.content, 'utf-8')
+
+    # TODO: abstract Py 2/3 check out to utils
+    if sys.version_info[0] < 3:
+        raw = request.content
+    else:
+        raw = str(request.content, 'utf-8')
 
     pending_json = json.loads(raw)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-requests==2.13.0
+requests==2.14.2
 sslyze==1.1.0
 wget==3.2
 docopt

--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,6 @@ setup(
         'Programming Language :: Python :: 2.6',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.3',
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
     ],

--- a/setup.py
+++ b/setup.py
@@ -46,6 +46,10 @@ setup(
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.6',
         'Programming Language :: Python :: 2.7',
+        'Programming Language :: Python :: 3',
+        'Programming Language :: Python :: 3.3',
+        'Programming Language :: Python :: 3.4',
+        'Programming Language :: Python :: 3.5',
     ],
 
     # What does your project relate to?
@@ -54,7 +58,7 @@ setup(
     packages=['pshtt'],
 
     install_requires=[
-        'requests>=2.10.0',
+        'requests>=2.14.2',
         'sslyze>=1.1.0',
         'wget>=3.2',
         'docopt',


### PR DESCRIPTION
This PR takes advantage of `sslyze`'s new Python 3 support, and builds on #70 to allow `pshtt` to be run in Python 3.

From my testing, `pshtt` should also continue to work in Python 2 as well. However, we could decide to abandon support for Python 2.

Some things I haven't tested, and probably need review:

* Running the tool **without** a `pip install` workflow. I've only run it after doing `pip install -e .` in the root of the dir, and then running `pshtt` directly.
* The Dockerfile. I haven't updated it at all for Python 3.
* More code paths than just `pshtt -d -j example.com`