### PR TITLE
Refactored base domain hsts preload check to reduce code reuse.

### DIFF
--- a/pshtt/pshtt.py
+++ b/pshtt/pshtt.py
@@ -724,7 +724,7 @@ def is_hsts_preloaded(domain):
 
 # Whether a domain's parent domain is in Chrome's HSTS preload list.
 def is_parent_hsts_preloaded(domain):
-    return parent_domain_for(domain.domain) in preload_list
+    return is_hsts_preloaded(Domain(parent_domain_for(domain.domain)))
 
 
 # For "x.y.domain.gov", return "domain.gov".


### PR DESCRIPTION
Used is_hsts_preloaded() to prevent duplicate code. 

Could potentially refactor is_hsts_preloaded() to utilize the hostname as a parameter rather than a Domain object as that is the only information needed by check. This would prevent the need from creating a new Domain object in is_parent_hsts_preloaded().