### PR TITLE
Fix crash upon redirects when there's no Location header

### DIFF
--- a/pshtt/pshtt.py
+++ b/pshtt/pshtt.py
@@ -203,7 +203,8 @@ def basic_check(endpoint):
     endpoint.headers = req.headers
 
     endpoint.status = req.status_code
-    if str(endpoint.status).startswith('3'):
+
+    if (req.headers.get('Location') != None) and str(endpoint.status).startswith('3'):
         endpoint.redirect = True
 
     if endpoint.redirect:

--- a/pshtt/pshtt.py
+++ b/pshtt/pshtt.py
@@ -204,7 +204,7 @@ def basic_check(endpoint):
 
     endpoint.status = req.status_code
 
-    if (req.headers.get('Location') != None) and str(endpoint.status).startswith('3'):
+    if (req.headers.get('Location') is not None) and str(endpoint.status).startswith('3'):
         endpoint.redirect = True
 
     if endpoint.redirect:


### PR DESCRIPTION
We weren't handling the edge case where a server returns a 3XX status code, but no `Location` header. This was resulting in a crash.

Thanks to @IanLee1521 for reporting this and suggesting the fix. Fixes #78.