### PR TITLE
Exceptions galore

### DIFF
--- a/pshtt/models.py
+++ b/pshtt/models.py
@@ -9,7 +9,7 @@ class Domain:
         self.httpwww = None
         self.https = None
         self.httpswww = None
-        self.unknownerror = None
+        self.unknown_error = False
 
         # Filled in after analyzing each endpoint.
         self.canonical = None
@@ -37,7 +37,7 @@ class Endpoint:
         self.status = None
         self.live = None
         self.redirect = None
-        self.unknownerror = None
+        self.unknown_error = False
 
         # If an endpoint redirects, characterize the redirect behavior
         self.redirect_immediately_to = None
@@ -94,7 +94,7 @@ class Endpoint:
             'redirect_eventually_to_http': self.redirect_eventually_to_http,
             'redirect_eventually_to_external': self.redirect_eventually_to_external,
             'redirect_eventually_to_subdomain': self.redirect_eventually_to_subdomain,
-            'unknown_error': self.unknownerror,
+            'unknown_error': self.unknown_error,
         }
 
         if self.protocol == "https":

--- a/pshtt/pshtt.py
+++ b/pshtt/pshtt.py
@@ -6,7 +6,6 @@ from publicsuffix import PublicSuffixList
 from publicsuffix import fetch
 
 import requests
-# import requests_cache
 import re
 import base64
 import json
@@ -215,8 +214,7 @@ def basic_check(endpoint):
 
     except Exception as err:
         endpoint.unknownerror = True
-        logging.warn("Unexpected other unknown exception during initial\
-                request.")
+        logging.warn("Unexpected other unknown exception during initial request.")
         logging.debug("{0}".format(err))
         return
 
@@ -248,9 +246,8 @@ def basic_check(endpoint):
             # Swallow connection errors, but we won't be saving redirect info.
             pass
         except Exception as err:
-            endpoint.unknonwnerror = True
-            logging.warn("Unexpected other unknown exception when handling\
-                    redirect.")
+            endpoint.unknownerror = True
+            logging.warn("Unexpected other unknown exception when handling redirect.")
             logging.debug("{0}".format(err))
             pass
 
@@ -355,7 +352,7 @@ def hsts_check(endpoint):
             endpoint.hsts_preload = True
     except Exception as err:
         endpoint.unknownerror = True
-        logging.warn("Unknown exception when handling hsts check.")
+        logging.warn("Unknown exception when handling HSTS check.")
         logging.debug("{0}".format(err))
         return
 
@@ -370,8 +367,7 @@ def https_check(endpoint):
         server_info = sslyze.server_connectivity.ServerConnectivityInfo(hostname=hostname, port=443)
     except Exception as err:
         endpoint.unknownerror = True
-        logging.warn("Unknown exception when checking server connectivity info\
-            with sslyze.")
+        logging.warn("Unknown exception when checking server connectivity info with sslyze.")
         logging.debug("{0}".format(err))
         return
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ docopt
 requests_cache
 pytablewriter
 publicsuffix
+pyopenssl=17.2.0


### PR DESCRIPTION
This PR covers a few different things, but all in the family of error handling. I'm outfitting pshtt to run on any site -- turns out websites on the internet have weird behaviors.  

Some of the error handling here is more specific than others --- for the specific error handling, I provide domains. 

This addition of error handling gives signals to the user where there was an unknown exception --- while some debugging statements are provided, debugging will still need to be done with other tools. 

1) Add exception handling to almost any place where the program relies on external programs. This includes sslyze, requests, etc. This does not include the preloading or any string parsing, variable grabbing, etc. 
2) Add an "unknown_error" field to endpoints so that one can figure out exactly which endpoint had an unknown exception. Add "Unknown Error" at the top level so that it's easy to flag. 
3) Add debug messaging for the unknown exceptions.
4) Add specific OpenSSL error handling in basic_check. This catches an OpenSSL error with whoohoo.co.uk
5) Add specific error handling in hsts_check. This catches errors with mominoun.com.

Happy to discuss any of these decisions in more detail. 