### PR TITLE
Use your own CA bundle from the command line

### DIFF
--- a/pshtt/cli.py
+++ b/pshtt/cli.py
@@ -3,7 +3,7 @@
 """pshtt ("pushed") is a tool to test domains for HTTPS best practices.
 
 Usage:
-  pshtt (INPUT ...) [--output OUTFILE] [--sorted] [--json] [--markdown] [--debug] [--timeout TIMEOUT] [--user-agent AGENT] [--preload-cache PRELOAD] [--cache] [--suffix-cache SUFFIX]
+  pshtt (INPUT ...) [--output OUTFILE] [--sorted] [--json] [--markdown] [--debug] [--timeout TIMEOUT] [--user-agent AGENT] [--preload-cache PRELOAD] [--cache] [--suffix-cache SUFFIX] [--ca-file PATH]
   pshtt (-h | --help)
 
 Options:
@@ -18,6 +18,7 @@ Options:
   -p --preload-cache=PRELOAD  Cache preload list, and where to cache it.
   -c --cache                  Cache network requests to a directory.
   -l --suffix-cache=SUFFIX    Cache suffix list, and where to cache it.
+  -f --ca-file=PATH           Specify custom CA bundle (PEM format)
 
 Notes:
   If the first INPUT ends with .csv, domains will be read from CSV.
@@ -56,7 +57,8 @@ def main():
         'timeout': args['--timeout'],
         'preload_cache': args['--preload-cache'],
         'suffix_cache': args['--suffix-cache'],
-        'cache': args['--cache']
+        'cache': args['--cache'],
+        'ca_file': args['--ca-file']
     }
     results = pshtt.inspect_domains(domains, options)
 

--- a/pshtt/pshtt.py
+++ b/pshtt/pshtt.py
@@ -922,8 +922,7 @@ def csv_for(results, out_filename):
 
 def inspect_domains(domains, options):
     # Override timeout, user agent, preload cache, default CA bundle
-    global TIMEOUT, USER_AGENT, PRELOAD_CACHE, WEB_CACHE, SUFFIX_CACHE,\
-            CA_FILE, STORE
+    global TIMEOUT, USER_AGENT, PRELOAD_CACHE, WEB_CACHE, SUFFIX_CACHE, CA_FILE, STORE
 
     if options.get('timeout'):
         TIMEOUT = int(options['timeout'])

--- a/pshtt/pshtt.py
+++ b/pshtt/pshtt.py
@@ -59,6 +59,8 @@ suffix_list = None
 
 # Set is user wants to use a custom CA bundle
 CA_FILE = None
+STORE = "Mozilla"
+
 
 def inspect(base_domain):
     domain = Domain(base_domain)
@@ -361,24 +363,19 @@ def https_check(endpoint):
         logging.warn("Known error in sslyze 1.X with EC public keys. See https://github.com/nabla-c0d3/sslyze/issues/215")
         return None
 
-    # Debugging   
-    for msg in cert_response:
-        print(msg)
-  
-    # By default, the store that we want to check is the Mozilla store
-    # However, if a user wants to use their own CA bundle, check the
-    # "Custom" Option from the sslyze output.
-    store = "Mozilla"
-    if CA_FILE:
-        store = "Custom"
+    # Debugging
+    # for msg in cert_response:
+    #     print(msg)
+
+    # STORE will be either "Mozilla" or "Custom"
+    # depending on what the user chose.
 
     # A certificate can have multiple issues.
     for msg in cert_response:
 
         # Check for certificate expiration.
         if (
-            #(("Mozilla NSS CA Store") in msg) and   
-            (store in msg) and
+            (STORE in msg) and
             (("FAILED") in msg) and
             (("certificate has expired") in msg)
         ):
@@ -387,8 +384,7 @@ def https_check(endpoint):
         # Check for whether there's a valid chain to Mozilla.
         # Note: this will also catch expired certs, but this is okay.
         if (
-            #(("Mozilla NSS CA Store") in msg) and
-            (store in msg) and
+            (STORE in msg) and
             (("FAILED") in msg) and
             (("Certificate is NOT Trusted") in msg)
         ):
@@ -927,7 +923,7 @@ def csv_for(results, out_filename):
 def inspect_domains(domains, options):
     # Override timeout, user agent, preload cache, default CA bundle
     global TIMEOUT, USER_AGENT, PRELOAD_CACHE, WEB_CACHE, SUFFIX_CACHE,\
-            CA_FILE
+            CA_FILE, STORE
 
     if options.get('timeout'):
         TIMEOUT = int(options['timeout'])
@@ -950,6 +946,10 @@ def inspect_domains(domains, options):
         SUFFIX_CACHE = options['suffix_cache']
     if options.get('ca_file'):
         CA_FILE = options['ca_file']
+        # By default, the store that we want to check is the Mozilla store
+        # However, if a user wants to use their own CA bundle, check the
+        # "Custom" Option from the sslyze output.
+        STORE = "Custom"
 
     # Download HSTS preload list, caches locally.
     global preload_list

--- a/pshtt/pshtt.py
+++ b/pshtt/pshtt.py
@@ -57,7 +57,7 @@ preload_pending = None
 SUFFIX_CACHE = None
 suffix_list = None
 
-# Set is user wants to use a custom CA bundle
+# Set if user wants to use a custom CA bundle
 CA_FILE = None
 STORE = "Mozilla"
 


### PR DESCRIPTION
Right now, you can only specify which CA bundle you want to use for requests, and via an environment variable. 

This PR allows you to specific a CA bundle using the command line, and will use the (same) CA bundle for both requests and sslyze. 

This PR also includes modified sslyze output parsing to take this decision into account --- if you use a custom CA bundle, it will only check the output from sslyze for that custom bundle. If you do not, it will continue to look for "Mozilla" as the default. 