### PR TITLE
Explicitly defaults HTTPS validation fields to false instead of null

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ todo.txt
 *.sqlite
 
 .cache/
+cache/
 
 # Byte-compiled / optimized / DLL files
 __pycache__/

--- a/pshtt/pshtt.py
+++ b/pshtt/pshtt.py
@@ -359,6 +359,12 @@ def https_check(endpoint):
     # for msg in cert_response:
     #     print(msg)
 
+    # Default endpoint assessments to False until proven True.
+    endpoint.https_expired_cert = False
+    endpoint.https_self_signed_cert = False
+    endpoint.https_bad_chain = False
+    endpoint.https_bad_hostname = False
+
     # A certificate can have multiple issues.
     for msg in cert_response:
 
@@ -377,6 +383,7 @@ def https_check(endpoint):
             (("self signed certificate") in msg)
         ):
             endpoint.https_self_signed_cert = True
+
         # Check to see if there is a bad chain
 
         # NOTE: If this is the only flag that's set, it's probably


### PR DESCRIPTION
This chips away at a larger issue in `pshtt`, and sets a few HTTPS validation fields explicitly to `False` before checking whether they are `True`.

Builds on #81.