### PR TITLE
Redirect error handling

### DIFF
--- a/pshtt/pshtt.py
+++ b/pshtt/pshtt.py
@@ -241,8 +241,6 @@ def basic_check(endpoint):
     if endpoint.redirect:
         try:
             location_header = req.headers.get('Location')
-            print(req.headers)
-            print(location_header)
             # Absolute redirects (e.g. "https://example.com/Index.aspx")
             if location_header.startswith("http:") or location_header.startswith("https:"):
                 immediate = location_header
@@ -269,7 +267,7 @@ def basic_check(endpoint):
             endpoint.unknown_error = True
             logging.warn("Unexpected other unknown exception when handling redirect.")
             logging.debug("{0}".format(err))
-            pass
+            return
 
         try:
             # Now establish whether the redirects were:

--- a/pshtt/pshtt.py
+++ b/pshtt/pshtt.py
@@ -261,7 +261,6 @@ def basic_check(endpoint):
             pass
 
         try:
-            print('endpoint url ',endpoint.url)
             ultimate_req = ping(endpoint.url, allow_redirects=True, verify=False)
         except requests.exceptions.RequestException:
             # Swallow connection errors, but we won't be saving redirect info.
@@ -286,10 +285,7 @@ def basic_check(endpoint):
             # The hostname of the immediate redirect.
             # The parent domain of the immediate redirect.
             subdomain_immediate = urlparse.urlparse(immediate).hostname
-            #if subdomain_immediate is not None:
-            #    base_immediate = parent_domain_for(subdomain_immediate)
-            #else:
-            #    base_immediate = None
+            base_immediate = parent_domain_for(subdomain_immediate)
 
             endpoint.redirect_immediately_to = immediate
             endpoint.redirect_immediately_to_www = re.match(r'^https?://www\.', immediate)

--- a/pshtt/pshtt.py
+++ b/pshtt/pshtt.py
@@ -239,20 +239,29 @@ def basic_check(endpoint):
         endpoint.redirect = True
 
     if endpoint.redirect:
-
-        location_header = req.headers.get('Location')
-        # Absolute redirects (e.g. "https://example.com/Index.aspx")
-        if location_header.startswith("http:") or location_header.startswith("https:"):
-            immediate = location_header
-
-        # Relative redirects (e.g. "Location: /Index.aspx").
-        # Construct absolute URI, relative to original request.
-        else:
-            immediate = urlparse.urljoin(endpoint.url, location_header)
-
-        # Chase down the ultimate destination, ignoring any certificate warnings.
-        ultimate_req = None
         try:
+            location_header = req.headers.get('Location')
+            print(req.headers)
+            print(location_header)
+            # Absolute redirects (e.g. "https://example.com/Index.aspx")
+            if location_header.startswith("http:") or location_header.startswith("https:"):
+                immediate = location_header
+
+            # Relative redirects (e.g. "Location: /Index.aspx").
+            # Construct absolute URI, relative to original request.
+            else:
+                immediate = urlparse.urljoin(endpoint.url, location_header)
+
+            # Chase down the ultimate destination, ignoring any certificate warnings.
+            ultimate_req = None
+        except Exception as err:
+            endpoint.unknown_error = True
+            logging.warn("Unexpected other unknown exception when handling Requests Header.")
+            logging.debug("{0}".format(err))
+            pass
+
+        try:
+            print('endpoint url ',endpoint.url)
             ultimate_req = ping(endpoint.url, allow_redirects=True, verify=False)
         except requests.exceptions.RequestException:
             # Swallow connection errors, but we won't be saving redirect info.
@@ -263,62 +272,71 @@ def basic_check(endpoint):
             logging.debug("{0}".format(err))
             pass
 
-        # Now establish whether the redirects were:
-        # * internal (same exact hostname),
-        # * within the zone (any subdomain within the parent domain)
-        # * external (on some other parent domain)
+        try:
+            # Now establish whether the redirects were:
+            # * internal (same exact hostname),
+            # * within the zone (any subdomain within the parent domain)
+            # * external (on some other parent domain)
 
-        # The hostname of the endpoint (e.g. "www.agency.gov")
-        subdomain_original = urlparse.urlparse(endpoint.url).hostname
-        # The parent domain of the endpoint (e.g. "agency.gov")
-        base_original = parent_domain_for(subdomain_original)
+            # The hostname of the endpoint (e.g. "www.agency.gov")
+            subdomain_original = urlparse.urlparse(endpoint.url).hostname
+            # The parent domain of the endpoint (e.g. "agency.gov")
+            base_original = parent_domain_for(subdomain_original)
 
-        # The hostname of the immediate redirect.
-        # The parent domain of the immediate redirect.
-        subdomain_immediate = urlparse.urlparse(immediate).hostname
-        base_immediate = parent_domain_for(subdomain_immediate)
+            # The hostname of the immediate redirect.
+            # The parent domain of the immediate redirect.
+            subdomain_immediate = urlparse.urlparse(immediate).hostname
+            #if subdomain_immediate is not None:
+            #    base_immediate = parent_domain_for(subdomain_immediate)
+            #else:
+            #    base_immediate = None
 
-        endpoint.redirect_immediately_to = immediate
-        endpoint.redirect_immediately_to_www = re.match(r'^https?://www\.', immediate)
-        endpoint.redirect_immediately_to_https = immediate.startswith("https://")
-        endpoint.redirect_immediately_to_http = immediate.startswith("http://")
-        endpoint.redirect_immediately_to_external = (base_original != base_immediate)
-        endpoint.redirect_immediately_to_subdomain = (
-            (base_original == base_immediate) and
-            (subdomain_original != subdomain_immediate)
-        )
-
-        if ultimate_req is not None:
-            # For ultimate destination, use the URL we arrived at,
-            # not Location header. Auto-resolves relative redirects.
-            eventual = ultimate_req.url
-
-            # The hostname of the eventual destination.
-            # The parent domain of the eventual destination.
-            subdomain_eventual = urlparse.urlparse(eventual).hostname
-            base_eventual = parent_domain_for(subdomain_eventual)
-
-            endpoint.redirect_eventually_to = eventual
-            endpoint.redirect_eventually_to_https = eventual.startswith("https://")
-            endpoint.redirect_eventually_to_http = eventual.startswith("http://")
-            endpoint.redirect_eventually_to_external = (base_original != base_eventual)
-            endpoint.redirect_eventually_to_subdomain = (
-                (base_original == base_eventual) and
-                (subdomain_original != subdomain_eventual)
+            endpoint.redirect_immediately_to = immediate
+            endpoint.redirect_immediately_to_www = re.match(r'^https?://www\.', immediate)
+            endpoint.redirect_immediately_to_https = immediate.startswith("https://")
+            endpoint.redirect_immediately_to_http = immediate.startswith("http://")
+            endpoint.redirect_immediately_to_external = (base_original != base_immediate)
+            endpoint.redirect_immediately_to_subdomain = (
+                (base_original == base_immediate) and
+                (subdomain_original != subdomain_immediate)
             )
 
-        # If we were able to make the first redirect, but not the ultimate redirect,
-        # and if the immediate redirect is external, then it's accurate enough to
-        # say that the eventual redirect is the immediate redirect, since you're capturing
-        # the domain it's going to.
-        # This also avoids "punishing" the domain for configuration issues of the site
-        # it redirects to.
-        elif endpoint.redirect_immediately_to_external:
-            endpoint.redirect_eventually_to = endpoint.redirect_immediately_to
-            endpoint.redirect_eventually_to_https = endpoint.redirect_immediately_to_https
-            endpoint.redirect_eventually_to_http = endpoint.redirect_immediately_to_http
-            endpoint.redirect_eventually_to_external = endpoint.redirect_immediately_to_external
-            endpoint.redirect_eventually_to_subdomain = endpoint.redirect_immediately_to_subdomain
+            if ultimate_req is not None:
+                # For ultimate destination, use the URL we arrived at,
+                # not Location header. Auto-resolves relative redirects.
+                eventual = ultimate_req.url
+
+                # The hostname of the eventual destination.
+                # The parent domain of the eventual destination.
+                subdomain_eventual = urlparse.urlparse(eventual).hostname
+                base_eventual = parent_domain_for(subdomain_eventual)
+
+                endpoint.redirect_eventually_to = eventual
+                endpoint.redirect_eventually_to_https = eventual.startswith("https://")
+                endpoint.redirect_eventually_to_http = eventual.startswith("http://")
+                endpoint.redirect_eventually_to_external = (base_original != base_eventual)
+                endpoint.redirect_eventually_to_subdomain = (
+                    (base_original == base_eventual) and
+                    (subdomain_original != subdomain_eventual)
+                )
+
+            # If we were able to make the first redirect, but not the ultimate redirect,
+            # and if the immediate redirect is external, then it's accurate enough to
+            # say that the eventual redirect is the immediate redirect, since you're capturing
+            # the domain it's going to.
+            # This also avoids "punishing" the domain for configuration issues of the site
+            # it redirects to.
+            elif endpoint.redirect_immediately_to_external:
+                endpoint.redirect_eventually_to = endpoint.redirect_immediately_to
+                endpoint.redirect_eventually_to_https = endpoint.redirect_immediately_to_https
+                endpoint.redirect_eventually_to_http = endpoint.redirect_immediately_to_http
+                endpoint.redirect_eventually_to_external = endpoint.redirect_immediately_to_external
+                endpoint.redirect_eventually_to_subdomain = endpoint.redirect_immediately_to_subdomain
+        except Exception as err:
+            endpoint.unknown_error = True
+            logging.warn("Unexpected other unknown exception when establishing redirects.")
+            logging.debug("{0}".format(err))
+            pass
 
 
 # Given an endpoint and its detected headers, extract and parse


### PR DESCRIPTION
nomadtravel.co.uk causes PSL to error out. This is because their Location in the req headers is incorrect (http:///), which causes the subdomain_immediate to be incorrect, which causes PSL to error out and crash the program. I've added an unknown_error here to handle this and any other websites that might have invalid location headers. 