### PR TITLE
Fixed regex

### DIFF
--- a/pshtt/pshtt.py
+++ b/pshtt/pshtt.py
@@ -286,9 +286,7 @@ def basic_check(endpoint):
             base_immediate = parent_domain_for(subdomain_immediate)
 
             endpoint.redirect_immediately_to = immediate
-            endpoint.redirect_immediately_to_www = re.match(r'^https?://www\.', immediate)
-            if endpoint.redirect_immediately_to_www is not None:
-                endpoint.redirect_immediately_to_www = True
+            endpoint.redirect_immediately_to_www = (re.match(r'^https?://www\.', immediate) is not None)
             endpoint.redirect_immediately_to_https = immediate.startswith("https://")
             endpoint.redirect_immediately_to_http = immediate.startswith("http://")
             endpoint.redirect_immediately_to_external = (base_original != base_immediate)

--- a/pshtt/pshtt.py
+++ b/pshtt/pshtt.py
@@ -287,6 +287,8 @@ def basic_check(endpoint):
 
             endpoint.redirect_immediately_to = immediate
             endpoint.redirect_immediately_to_www = re.match(r'^https?://www\.', immediate)
+            if endpoint.redirect_immediately_to_www is not None:
+                endpoint.redirect_immediately_to_www = True
             endpoint.redirect_immediately_to_https = immediate.startswith("https://")
             endpoint.redirect_immediately_to_http = immediate.startswith("http://")
             endpoint.redirect_immediately_to_external = (base_original != base_immediate)


### PR DESCRIPTION
My understanding is that when you have a match with a python regex, it returns an object; if you don't, it returns None. I found this when debugging definitivetechnology.com --- some of the endpoints redirected immediately to www, but the json contradicted itself. 

This PR fixes this problem and correctly sets redirect_immediately_to_www to True when applicable. You can observe this with the httpwww endpoint in definitivetechnology.com