### PR TITLE
Https redirects

### DIFF
--- a/pshtt/pshtt.py
+++ b/pshtt/pshtt.py
@@ -330,12 +330,13 @@ def basic_check(endpoint):
             pass
 
     # Here we check if the site had valid https
-    # We check after the redirect logic because it is possible that 
+    # We check after the redirect logic because it is possible that
     # a site would redirect immediately or evetually to a non https site
     # We need to be able to catch this
-    if endpoint.protocol == 'https' and endpoint.live == True: 
+    if endpoint.protocol == 'https' and endpoint.live:
         if not endpoint.redirect_immediately_to_http:
             endpoint.https_valid = True
+
 
 # Given an endpoint and its detected headers, extract and parse
 # any present HSTS header, decide what HSTS properties are there.

--- a/pshtt/pshtt.py
+++ b/pshtt/pshtt.py
@@ -170,10 +170,7 @@ def basic_check(endpoint):
     # * Validate certificates. (Will figure out error if necessary.)
     try:
         req = ping(endpoint.url)
-
         endpoint.live = True
-        if endpoint.protocol == "https":
-            endpoint.https_valid = True
 
     except requests.exceptions.SSLError as err:
         logging.warn("Error validating certificate.")
@@ -332,6 +329,13 @@ def basic_check(endpoint):
             logging.debug("{0}".format(err))
             pass
 
+    # Here we check if the site had valid https
+    # We check after the redirect logic because it is possible that 
+    # a site would redirect immediately or evetually to a non https site
+    # We need to be able to catch this
+    if endpoint.protocol == 'https' and endpoint.live == True: 
+        if not endpoint.redirect_immediately_to_http and not endpoint.redirect_eventually_to_http:
+            endpoint.https_valid = True
 
 # Given an endpoint and its detected headers, extract and parse
 # any present HSTS header, decide what HSTS properties are there.

--- a/pshtt/pshtt.py
+++ b/pshtt/pshtt.py
@@ -334,7 +334,7 @@ def basic_check(endpoint):
     # a site would redirect immediately or evetually to a non https site
     # We need to be able to catch this
     if endpoint.protocol == 'https' and endpoint.live == True: 
-        if not endpoint.redirect_immediately_to_http and not endpoint.redirect_eventually_to_http:
+        if not endpoint.redirect_immediately_to_http:
             endpoint.https_valid = True
 
 # Given an endpoint and its detected headers, extract and parse


### PR DESCRIPTION
This fixes a bug in the https validity checker.

Previously, if a site was live at an https endpoint, it would be flagged as valid https. However, it is possible that site it live but immediately redirect to an http site. If this does not happen, THEN we go ahead and say that the site has valid https. 

This behaviour can be seen on a variety of sites: http://metro.co.uk/, debenhams.com, espn.com.