### PR TITLE
Update timeout

### DIFF
--- a/pshtt/pshtt.py
+++ b/pshtt/pshtt.py
@@ -35,7 +35,7 @@ WEB_CACHE = None
 USER_AGENT = "pshtt, https scanning"
 
 # Defaults to 1 second, overrideable via --timeout
-TIMEOUT = 1
+TIMEOUT = 10
 
 # The fields we're collecting, will be keys in JSON and
 # column headers in CSV.

--- a/pshtt/pshtt.py
+++ b/pshtt/pshtt.py
@@ -34,7 +34,7 @@ WEB_CACHE = None
 # Default, overrideable via --user-agent
 USER_AGENT = "pshtt, https scanning"
 
-# Defaults to 1 second, overrideable via --timeout
+# Defaults to 10 second, overrideable via --timeout
 TIMEOUT = 10
 
 # The fields we're collecting, will be keys in JSON and


### PR DESCRIPTION
I'm opening up this PR because of a debugging adventure that konklone@ and I went down on, which essentially ended up in the fact that the website worked 100% ok if you put a longer timeout. I think the default timeout for pshtt should be much higher, to account for laggy websites on the internet. 

I did a test on a random 10K subset of the Alexa 1 million and found the following (apologies for lack of formatting).

Timeout | Total liveness
5sec | 9640
10sec | 9651
15sec | 9654
20sec | 9655

Timeout | Number of endpoints to come online
5->10sec | 105
10->15sec | 75
15sec->20sec | 65

Breakdown of number of endpoints to come online
Timeout | 1 endpoint | 2 endpoints | 3 endpoints | 4 endpoints
5->10sec | 2 | 25 | 7 | 71
10->15sec | 3 | 15 | 5 | 52
15sec->20sec | 2 | 14 | 7 | 42

As we can see, 5 seconds captures a lot of websites, but if you increase to 10 seconds, not only do you find 11 more websites come online, but you also find a larger number of endpoints come online. 

Based on these numbers, I propose that the default timeout be 10 seconds to account for the nature of websites on the internet. 
