### PR TITLE
Adding some whitespace to the debugging output.

### DIFF
--- a/pshtt/cli.py
+++ b/pshtt/cli.py
@@ -69,6 +69,7 @@ def main():
             print(output)
         else:
             utils.write(output, out_file)
+            logging.debug("\n-------------------------\n")
             logging.warn("Wrote results to %s." % out_file)
     # Markdwon can go to STDOUT, or to a file
     elif args['--markdown']:
@@ -85,6 +86,7 @@ def main():
         if args['--output'] is None:
             out_file = 'results.csv'
         pshtt.csv_for(results, out_file)
+        logging.debug("\n-------------------------\n")
         logging.warn("Wrote results to %s." % out_file)
 
 

--- a/pshtt/pshtt.py
+++ b/pshtt/pshtt.py
@@ -158,7 +158,8 @@ def ping(url, allow_redirects=False, verify=True):
 
 
 def basic_check(endpoint):
-    logging.debug("Pinging %s..." % endpoint.url)
+    logging.debug("\n-------------------------\n")
+    logging.debug("Pinging %s...\n" % endpoint.url)
 
     # Test the endpoint. At first:
     #
@@ -177,7 +178,7 @@ def basic_check(endpoint):
 
     except requests.exceptions.SSLError as err:
         logging.warn("Error validating certificate.")
-        logging.debug("{0}".format(err))
+        logging.debug("{0}\n".format(err))
 
         # Retry with certificate validation disabled.
         try:
@@ -186,22 +187,22 @@ def basic_check(endpoint):
             # If it's a protocol error or other, it's not live.
             endpoint.live = False
             logging.warn("Unexpected SSL protocol (or other) error during retry.")
-            logging.debug("{0}".format(err))
+            logging.debug("{0}\n".format(err))
             return
         except requests.exceptions.RequestException as err:
             endpoint.live = False
             logging.warn("Unexpected requests exception during retry.")
-            logging.debug("{0}".format(err))
+            logging.debug("{0}\n".format(err))
             return
         except OpenSSL.SSL.Error as err:
             endpoint.live = False
             logging.warn("Unexpected OpenSSL exception during retry.")
-            logging.debug("{0}".format(err))
+            logging.debug("{0}\n".format(err))
             return
         except Exception as err:
             endpoint.unknown_error = True
             logging.warn("Unexpected other unknown exception during requests retry.")
-            logging.debug("{0}".format(err))
+            logging.debug("{0}\n".format(err))
             return
 
         # If it was a certificate error of any kind, it's live.
@@ -212,7 +213,7 @@ def basic_check(endpoint):
 
     except requests.exceptions.ConnectionError as err:
         endpoint.live = False
-        logging.debug("{0}".format(err))
+        logging.debug("{0}\n".format(err))
         return
 
     # And this is the parent of ConnectionError and other things.
@@ -221,13 +222,13 @@ def basic_check(endpoint):
     except requests.exceptions.RequestException as err:
         endpoint.live = False
         logging.warn("Unexpected other requests exception.")
-        logging.debug("{0}".format(err))
+        logging.debug("{0}\n".format(err))
         return
 
     except Exception as err:
         endpoint.unknown_error = True
         logging.warn("Unexpected other unknown exception during initial request.")
-        logging.debug("{0}".format(err))
+        logging.debug("{0}\n".format(err))
         return
 
     # Endpoint is live, analyze the response.
@@ -255,7 +256,7 @@ def basic_check(endpoint):
         except Exception as err:
             endpoint.unknown_error = True
             logging.warn("Unexpected other unknown exception when handling Requests Header.")
-            logging.debug("{0}".format(err))
+            logging.debug("{0}\n".format(err))
             pass
 
         try:
@@ -266,7 +267,7 @@ def basic_check(endpoint):
         except Exception as err:
             endpoint.unknown_error = True
             logging.warn("Unexpected other unknown exception when handling redirect.")
-            logging.debug("{0}".format(err))
+            logging.debug("{0}\n".format(err))
             return
 
         try:
@@ -329,7 +330,7 @@ def basic_check(endpoint):
         except Exception as err:
             endpoint.unknown_error = True
             logging.warn("Unexpected other unknown exception when establishing redirects.")
-            logging.debug("{0}".format(err))
+            logging.debug("{0}\n".format(err))
             pass
 
 
@@ -377,13 +378,13 @@ def hsts_check(endpoint):
     except Exception as err:
         endpoint.unknown_error = True
         logging.warn("Unknown exception when handling HSTS check.")
-        logging.debug("{0}".format(err))
+        logging.debug("{0}\n".format(err))
         return
 
 
 # Uses sslyze to figure out the reason the endpoint wouldn't verify.
 def https_check(endpoint):
-    logging.debug("sslyzing %s..." % endpoint.url)
+    logging.debug("sslyzing %s...\n" % endpoint.url)
 
     # remove the https:// from prefix for sslyze
     try:
@@ -392,19 +393,19 @@ def https_check(endpoint):
     except Exception as err:
         endpoint.unknown_error = True
         logging.warn("Unknown exception when checking server connectivity info with sslyze.")
-        logging.debug("{0}".format(err))
+        logging.debug("{0}\n".format(err))
         return
 
     try:
         server_info.test_connectivity_to_server()
     except sslyze.server_connectivity.ServerConnectivityError as err:
         logging.warn("Error in sslyze server connectivity check")
-        logging.debug("{0}".format(err))
+        logging.debug("{0}\n".format(err))
         return
     except Exception as err:
         endpoint.unknown_error = True
         logging.warn("Unknown exception in sslyze server connectivity check.")
-        logging.debug("{0}".format(err))
+        logging.debug("{0}\n".format(err))
         return
 
     try:
@@ -414,7 +415,7 @@ def https_check(endpoint):
     except Exception as err:
         endpoint.unknown_error = True
         logging.warn("Unknown exception in sslyze scanner.")
-        logging.debug("{0}".format(err))
+        logging.debug("{0}\n".format(err))
         return
 
     try:
@@ -425,7 +426,7 @@ def https_check(endpoint):
     except Exception as err:
         endpoint.unknown_error = True
         logging.warn("Unknown exception in cert plugin.")
-        logging.debug("{0}".format(err))
+        logging.debug("{0}\n".format(err))
         return
 
     # Debugging
@@ -916,7 +917,7 @@ def did_domain_error(domain):
 
 # Fetch the Chrome preload pending list. Don't cache, it's quick/small.
 def fetch_preload_pending():
-    logging.debug("Fetching Chrome pending preload list...")
+    logging.debug("Fetching Chrome pending preload list...\n")
 
     pending_url = "https://hstspreload.org/api/v2/pending"
     request = requests.get(pending_url)
@@ -941,10 +942,10 @@ def create_preload_list():
     preload_json = None
 
     if PRELOAD_CACHE and os.path.exists(PRELOAD_CACHE):
-        logging.debug("Using cached Chrome preload list.")
+        logging.debug("Using cached Chrome preload list.\n")
         preload_json = json.loads(open(PRELOAD_CACHE).read())
     else:
-        logging.debug("Fetching Chrome preload list from source...")
+        logging.debug("Fetching Chrome preload list from source...\n")
 
         # Downloads the chromium preloaded domain list and sets it to a global set
         file_url = 'https://chromium.googlesource.com/chromium/src/net/+/master/http/transport_security_state_static.json?format=TEXT'
@@ -967,7 +968,7 @@ def create_preload_list():
         preload_json = json.loads(raw)
 
         if PRELOAD_CACHE:
-            logging.debug("Caching preload list at %s" % PRELOAD_CACHE)
+            logging.debug("Caching preload list at %s\n" % PRELOAD_CACHE)
             utils.write(utils.json_for(preload_json), PRELOAD_CACHE)
 
     # For our purposes, we only care about entries that includeSubDomains
@@ -981,18 +982,18 @@ def create_preload_list():
 
 def load_suffix_list():
     if SUFFIX_CACHE and os.path.exists(SUFFIX_CACHE):
-        logging.debug("Using cached suffix list.")
+        logging.debug("Using cached suffix list.\n")
         cache_file = codecs.open(SUFFIX_CACHE, encoding='utf-8')
         suffixes = PublicSuffixList(cache_file)
     else:
         # File does not exist, download current list and cache it at given location.
-        logging.debug("Downloading the Public Suffix List...")
+        logging.debug("Downloading the Public Suffix List...\n")
         cache_file = fetch()
         content = cache_file.readlines()
         suffixes = PublicSuffixList(content)
 
         if SUFFIX_CACHE:
-            logging.debug("Caching suffix list at %s" % SUFFIX_CACHE)
+            logging.debug("Caching suffix list at %s\n" % SUFFIX_CACHE)
             utils.write(''.join(content), SUFFIX_CACHE)
 
     return suffixes
@@ -1070,13 +1071,16 @@ def inspect_domains(domains, options):
         STORE = "Custom"
 
     # Download HSTS preload list, caches locally.
+    logging.debug("\n-------------------------\n")
     global preload_list
     preload_list = create_preload_list()
 
     # Download HSTS pending preload list. Not cached.
+    logging.debug("\n-------------------------\n")
     global preload_pending
     preload_pending = fetch_preload_pending()
 
+    logging.debug("\n-------------------------\n")
     global suffix_list
     suffix_list = load_suffix_list()
 


### PR DESCRIPTION
The bunched up output when using --debug was difficult to read. This is a simple pull to space things out a bit. I'm going to work a separate pull (eventually) to *really* clean up output, but this should be a serviceable middle step.