### PR TITLE
add a script for running via Docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,4 @@
 FROM python:3.5-onbuild
 
 ENTRYPOINT ["./entrypoint.sh"]
+CMD ["--help"]

--- a/README.md
+++ b/README.md
@@ -76,16 +76,10 @@ pshtt --ca-file=/etc/ssl/ca.pem server.internal-location.gov
 ##### Using Docker (optional)
 
 ```bash
-docker build -t pshtt/cli .
-
-docker run --rm -it \
-  --name pshtt \
-  -v $(pwd):/data \
-  -e USER_ID=1042 \           /* Change the ownership of the files (**e.g** results)
-  -e GROUP_ID=1042 \         to the user with id 1042 and to the group with id 1042. */
-  pshtt/cli
+./run [opts]
 ```
 
+`opts` are the same arguments that would get passed to `pshtt`.
 
 ## What's Checked?
 

--- a/run
+++ b/run
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+set -e
+set -x
+
+
+docker build -t pshtt/cli .
+
+docker run --rm -it \
+  --name pshtt \
+  -v $(pwd):/data \
+  `# Change the ownership of the files (**e.g** results) to the user with id 1042 and to the group with id 1042` \
+  -e USER_ID=1042 \
+  -e GROUP_ID=1042 \
+  pshtt/cli $@


### PR DESCRIPTION
This simplifies running with Docker, hiding the complexity of the commands from the user.