### PR TITLE
Simplifying Docker usage of custom trust stores

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 todo.txt
 *.json
 *.sqlite
+*.pem
 
 .cache/
 cache/

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -28,6 +28,7 @@ fi
 
 # Copy the inputs
 cp /data/*.csv /usr/src/app
+cp /data/*.pem /usr/src/app
 
 python -m pshtt.cli "$@"
 


### PR DESCRIPTION
Just making a few changes that allow us to treat the PEM files that contain our custom trust stores like we do other `pshtt` inputs. Specifically, I'm copying those PEM files to the Docker /usr/src/app working directory and telling gitignore not to watch them.