### PR TITLE
Reports version information consistently

### DIFF
--- a/pshtt/cli.py
+++ b/pshtt/cli.py
@@ -34,7 +34,7 @@ import sys
 
 
 def main():
-    args = docopt.docopt(__doc__, version='v0.0.1')
+    args = docopt.docopt(__doc__, version='v0.2.3')
     utils.configure_logging(args['--debug'])
 
     out_file = args['--output']

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ setup(
     name='pshtt',
 
     # Versions should comply with PEP440
-    version='0.2.2',
+    version='0.2.3',
     description='Scan websites for HTTPS deployment best practices',
 
     # NCATS "homepage"


### PR DESCRIPTION
Fixes #105. The version reported is now 0.2.3 according to both the CLI and the setup.py file, which matches what's currently available on pip: https://pypi.python.org/pypi/pshtt/0.2.3

Releasing 0.2.4 will require these strings to be updated again. Happy to wire up an update-version script to handle that if maintainers would find it useful.