### PR TITLE
Default to building universal wheel

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,5 @@
+[bdist_wheel]
+universal = true
+
 [metadata]
 description-file = README.md


### PR DESCRIPTION
Because the project is pure Python and 2/3 compatible,
we can build a single wheel out of the package using:

`$ python setup.py bdist_wheel`

Ref: https://packaging.python.org/tutorials/distributing-packages/#universal-wheels