### PR TITLE
Add self-signed errors to bad chain calculation

### DIFF
--- a/pshtt/pshtt.py
+++ b/pshtt/pshtt.py
@@ -494,8 +494,10 @@ def https_check(endpoint):
         if (
             (STORE in msg) and
             (("FAILED") in msg) and
-            ((("unable to get local issuer certificate") in msg) or
-            (("self signed certificate") in msg))
+            (
+                (("unable to get local issuer certificate") in msg) or
+                (("self signed certificate") in msg)
+            )
         ):
             endpoint.https_bad_chain = True
 

--- a/pshtt/pshtt.py
+++ b/pshtt/pshtt.py
@@ -494,7 +494,8 @@ def https_check(endpoint):
         if (
             (STORE in msg) and
             (("FAILED") in msg) and
-            (("unable to get local issuer certificate") in msg)
+            ((("unable to get local issuer certificate") in msg) or
+            (("self signed certificate") in msg))
         ):
             endpoint.https_bad_chain = True
 


### PR DESCRIPTION
This is a small change with cascading effects: treating self-signed certificates in the certificate chain as "bad chain" errors. It is proposed to more accurately represent what constitutes bad chain errors, and also to more correctly score domains that "support HTTPS".

"Domain Supports HTTPS" is an adjudication of several factors. Even if a domain is "true" for "HTTPS Bad Chain", pshtt allows "Domain Supports HTTPS" to be true in recognition of the fact that a domain with certificate validation challenges does still _support_ the use of HTTPS. This change scores "HTTPS Bad Chain" as true when there is a self-signed certificate in the chain, which allows these domains to be scored as "supporting HTTPS".

This change does mean that any time a domain is "HTTPS Self Signed Cert"=="True" that "HTTPS Bad Chain" is true also. We may consider collapsing these fields into one, though I believe having a separate output for self-signed certs is helpful.