### PR TITLE
Updated Python versions support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ sudo: false
 
 python:
   - '2.7'
+  - '3.4'
   - '3.5'
   - '3.6'
 
@@ -13,4 +14,3 @@ install:
 
 script:
   - flake8 .
-

--- a/setup.py
+++ b/setup.py
@@ -49,6 +49,7 @@ setup(
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: 3.6',
     ],
 
     # What does your project relate to?


### PR DESCRIPTION
Travis was testing Python 3.6, not included in the setup.py
classifiers list. Meanwhile, 3.4 is in the classifiers, but
not being tested. This brings those two in sync.