### PR TITLE
pytablereader seems to require a newer version of requests

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-requests==2.14.2
+requests>=2.18.4
 sslyze==1.1.0
 wget==3.2
 docopt

--- a/setup.py
+++ b/setup.py
@@ -57,7 +57,7 @@ setup(
     packages=['pshtt'],
 
     install_requires=[
-        'requests>=2.14.2',
+        'requests>=2.18.4',
         'sslyze>=1.1.0',
         'wget>=3.2',
         'docopt',


### PR DESCRIPTION
When running the version of `pshtt` in `master` via `domain-scan`, I encountered scores of the following error:
> Error running ['pshtt', '012.tlsa.good.test.dnsops.gov', '--json', '--user-agent', '"github.com/18f/domain-scan, pshtt.py"', '--timeout', '30', '--preload-cache', './cache/preload-list.json'].
> scan_1   |      Bad news scanning, sorry!
> scan_1   | [090.nihweb5.cit.nih.gov][pshtt]
> scan_1   |       pshtt 090.nihweb5.cit.nih.gov
> scan_1   | Traceback (most recent call last):
> scan_1   |   File "/usr/local/lib/python3.4/dist-packages/pkg_resources/__init__.py", line 658, in _build_master
> scan_1   |     ws.require(__requires__)
> scan_1   |   File "/usr/local/lib/python3.4/dist-packages/pkg_resources/__init__.py", line 972, in require
> scan_1   |     needed = self.resolve(parse_requirements(requirements))
> scan_1   |   File "/usr/local/lib/python3.4/dist-packages/pkg_resources/__init__.py", line 863, in resolve
> scan_1   |     raise VersionConflict(dist, req).with_context(dependent_req)
> scan_1   | pkg_resources.ContextualVersionConflict: (requests 2.14.2 (/usr/local/lib/python3.4/dist-packages), Requirement.parse('requests>=2.18.4'), {'pytablereader'})

I was able to make these errors go away by updating the version of `requests` in `requirements.txt`.