### PR TITLE
Re-architecting of CSV / MD / JSON writing

### DIFF
--- a/pshtt/cli.py
+++ b/pshtt/cli.py
@@ -92,7 +92,7 @@ def main():
         with smart_open(out_filename) as out_file:
             json_content = utils.json_for(results)
 
-            out_file.write(json_content)
+            out_file.write(json_content + '\n')
 
             if out_file is not sys.stdout:
                 logging.warn("Wrote results to %s.", out_filename)

--- a/pshtt/cli.py
+++ b/pshtt/cli.py
@@ -80,20 +80,22 @@ def main():
         'cache': args['--cache'],
         'ca_file': args['--ca-file']
     }
+
+    # Do the domain inspections
     results = pshtt.inspect_domains(domains, options)
 
     # JSON can go to STDOUT, or to a file.
     if args['--json']:
-        # Generate all the results before exporting to JSON
+        # Generate (yield) all the results before exporting to JSON
         results = list(results)
 
-        output = utils.json_for(results)
-        if out_filename is None:
-            utils.debug("Printing JSON...", divider=True)
-            print(output)
-        else:
-            utils.write(output, out_filename)
-            logging.warn("Wrote results to %s." % out_filename)
+        with smart_open(out_filename) as out_file:
+            json_content = utils.json_for(results)
+
+            out_file.write(json_content)
+
+            if out_file is not sys.stdout:
+                logging.warn("Wrote results to %s.", out_filename)
 
     # Markdwon can go to STDOUT, or to a file
     elif args['--markdown']:

--- a/pshtt/cli.py
+++ b/pshtt/cli.py
@@ -29,10 +29,26 @@ from . import pshtt
 from . import utils
 from . import __version__
 
+import contextlib
 import csv
 import docopt
 import logging
 import sys
+
+
+@contextlib.contextmanager
+def smart_open(filename=None):
+    """Context manager that can handle writing to a file or stdout"""
+    if filename is None:
+        fh = sys.stdout
+    else:
+        fh = open(filename, 'w')
+
+    try:
+        yield fh
+    finally:
+        if fh is not sys.stdout:
+            fh.close()
 
 
 def main():
@@ -97,7 +113,7 @@ def main():
         if out_filename is None:
             out_filename = 'results.csv'
 
-        with open(out_filename, 'w') as out_file:
+        with smart_open(out_filename) as out_file:
             utils.debug("Opening CSV file: {}".format(out_filename))
             writer = csv.writer(out_file)
 

--- a/pshtt/cli.py
+++ b/pshtt/cli.py
@@ -35,6 +35,8 @@ import docopt
 import logging
 import sys
 
+import pytablewriter
+
 
 @contextlib.contextmanager
 def smart_open(filename=None):
@@ -95,18 +97,21 @@ def main():
 
     # Markdwon can go to STDOUT, or to a file
     elif args['--markdown']:
-        # Generate all the results before exporting to JSON
-        results = list(results)
-
-        output = sys.stdout
-        if out_filename is not None:
-            output = open(out_filename, 'w')
+        # Generate all the results before exporting to Markdown
+        table = [
+            [" %s" % result[header] for header in pshtt.HEADERS]
+            for result in results
+        ]
 
         utils.debug("Printing Markdown...", divider=True)
-        pshtt.md_for(results, output)
+        with smart_open(out_filename) as out_file:
+            writer = pytablewriter.MarkdownTableWriter()
 
-        if out_filename is not None:
-            output.close()
+            writer.header_list = pshtt.HEADERS
+            writer.value_matrix = table
+            writer.stream = out_file
+
+            writer.write_table()
 
     # CSV always goes to a file.
     else:

--- a/pshtt/cli.py
+++ b/pshtt/cli.py
@@ -28,29 +28,14 @@ Notes:
 from . import pshtt
 from . import utils
 from . import __version__
+from .utils import smart_open
 
-import contextlib
 import csv
 import docopt
 import logging
 import sys
 
 import pytablewriter
-
-
-@contextlib.contextmanager
-def smart_open(filename=None):
-    """Context manager that can handle writing to a file or stdout"""
-    if filename is None:
-        fh = sys.stdout
-    else:
-        fh = open(filename, 'w')
-
-    try:
-        yield fh
-    finally:
-        if fh is not sys.stdout:
-            fh.close()
 
 
 def main():

--- a/pshtt/cli.py
+++ b/pshtt/cli.py
@@ -113,8 +113,8 @@ def main():
         if out_filename is None:
             out_filename = 'results.csv'
 
+        utils.debug("Opening CSV file: {}".format(out_filename))
         with smart_open(out_filename) as out_file:
-            utils.debug("Opening CSV file: {}".format(out_filename))
             writer = csv.writer(out_file)
 
             # Write out header

--- a/pshtt/pshtt.py
+++ b/pshtt/pshtt.py
@@ -11,7 +11,6 @@ import base64
 import json
 import os
 import logging
-import pytablewriter
 import sys
 import codecs
 import OpenSSL
@@ -1088,26 +1087,6 @@ def load_suffix_list():
             utils.write(''.join(content), SUFFIX_CACHE)
 
     return suffixes
-
-
-def md_for(results, out_fd):
-    value_matrix = []
-    for result in results:
-        row = []
-        # TODO: Fix this upstream
-        for header in HEADERS:
-            if (header != "HSTS Header") and (header != "HSTS Max Age") and (header != "Redirect To"):
-                if result[header] is None:
-                    result[header] = False
-            row.append(" %s" % result[header])
-        value_matrix.append(row)
-
-    writer = pytablewriter.MarkdownTableWriter()
-    writer.header_list = HEADERS
-    writer.value_matrix = value_matrix
-
-    writer.stream = out_fd
-    writer.write_table()
 
 
 def inspect_domains(domains, options):

--- a/pshtt/pshtt.py
+++ b/pshtt/pshtt.py
@@ -9,7 +9,6 @@ import requests
 import re
 import base64
 import json
-import csv
 import os
 import logging
 import pytablewriter
@@ -133,6 +132,17 @@ def result_for(domain):
 
     # But also capture the extended data for those who want it.
     result['endpoints'] = domain.to_object()
+
+    # Convert Header fields from None to False, except for:
+    # - "HSTS Header"
+    # - "HSTS Max Age"
+    # - "Redirect To"
+    for header in HEADERS:
+        if header in ("HSTS Header", "HSTS Max Age", "Redirect To"):
+            continue
+
+        if result[header] is None:
+            result[header] = False
 
     return result
 
@@ -1100,29 +1110,6 @@ def md_for(results, out_fd):
     writer.write_table()
 
 
-def csv_for(results, out_filename):
-    """
-    Output a CSV string for an array of results, with a
-    header row, and with header fields in the desired order.
-    """
-    out_file = open(out_filename, 'w')
-    writer = csv.writer(out_file)
-
-    writer.writerow(HEADERS)
-
-    for result in results:
-        row = []
-        # TODO: Fix this upstream
-        for header in HEADERS:
-            if (header != "HSTS Header") and (header != "HSTS Max Age") and (header != "Redirect To"):
-                if result[header] is None:
-                    result[header] = False
-            row.append(result[header])
-        writer.writerow(row)
-
-    out_file.close()
-
-
 def inspect_domains(domains, options):
     # Override timeout, user agent, preload cache, default CA bundle
     global TIMEOUT, USER_AGENT, PRELOAD_CACHE, WEB_CACHE, SUFFIX_CACHE, CA_FILE, STORE
@@ -1165,8 +1152,5 @@ def inspect_domains(domains, options):
     suffix_list = load_suffix_list()
 
     # For every given domain, get inspect data.
-    results = []
     for domain in domains:
-        results.append(inspect(domain))
-
-    return results
+        yield inspect(domain)

--- a/pshtt/utils.py
+++ b/pshtt/utils.py
@@ -101,7 +101,11 @@ def debug(message, divider=False):
 
 @contextlib.contextmanager
 def smart_open(filename=None):
-    """Context manager that can handle writing to a file or stdout"""
+    """
+    Context manager that can handle writing to a file or stdout
+
+    Adapted from: https://stackoverflow.com/a/17603000
+    """
     if filename is None:
         fh = sys.stdout
     else:

--- a/pshtt/utils.py
+++ b/pshtt/utils.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 
+import contextlib
 import os
 import json
 import errno
@@ -96,3 +97,18 @@ def debug(message, divider=False):
 
     if message:
         logging.debug("%s\n" % message)
+
+
+@contextlib.contextmanager
+def smart_open(filename=None):
+    """Context manager that can handle writing to a file or stdout"""
+    if filename is None:
+        fh = sys.stdout
+    else:
+        fh = open(filename, 'w')
+
+    try:
+        yield fh
+    finally:
+        if fh is not sys.stdout:
+            fh.close()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -41,9 +41,9 @@ class TestToCSV(unittest.TestCase):
         with open(self.temp_filename) as fh:
             content = fh.read()
 
-            expected = 'Domain,Base Domain,Canonical URL,Live,Redirect,Redirect To,Valid HTTPS,Defaults to HTTPS,Downgrades HTTPS,Strictly Forces HTTPS,HTTPS Bad Chain,HTTPS Bad Hostname,HTTPS Expired Cert,HTTPS Self Signed Cert,HSTS,HSTS Header,HSTS Max Age,HSTS Entire Domain,HSTS Preload Ready,HSTS Preload Pending,HSTS Preloaded,Base Domain HSTS Preloaded,Domain Supports HTTPS,Domain Enforces HTTPS,Domain Uses Strong HSTS,Unknown Error\n'
+        expected = ','.join(_pshtt.HEADERS) + '\n'
 
-            self.assertEqual(content, expected)
+        self.assertEqual(content, expected)
 
     @unittest.skipIf(sys.version_info[0] < 3, 'Python 3 test only')
     def test_single_result(self):
@@ -52,8 +52,41 @@ class TestToCSV(unittest.TestCase):
         with open(self.temp_filename) as fh:
             content = fh.read()
 
-            expected = ''
-            expected += 'Domain,Base Domain,Canonical URL,Live,Redirect,Redirect To,Valid HTTPS,Defaults to HTTPS,Downgrades HTTPS,Strictly Forces HTTPS,HTTPS Bad Chain,HTTPS Bad Hostname,HTTPS Expired Cert,HTTPS Self Signed Cert,HSTS,HSTS Header,HSTS Max Age,HSTS Entire Domain,HSTS Preload Ready,HSTS Preload Pending,HSTS Preloaded,Base Domain HSTS Preloaded,Domain Supports HTTPS,Domain Enforces HTTPS,Domain Uses Strong HSTS,Unknown Error\n'
-            expected += 'example.com,example.com,http://example.com,False,False,,False,False,False,False,False,False,False,False,False,,,False,False,False,False,False,False,False,False,False\n'
+        domain_data = [
+            ('Domain', 'example.com'),
+            ('Base Domain', 'example.com'),
+            ('Canonical URL', 'http://example.com'),
+            ('Live', 'False'),
+            ('Redirect', 'False'),
+            ('Redirect To', ''),
+            ('Valid HTTPS', 'False'),
+            ('Defaults to HTTPS', 'False'),
+            ('Downgrades HTTPS', 'False'),
+            ('Strictly Forces HTTPS', 'False'),
+            ('HTTPS Bad Chain', 'False'),
+            ('HTTPS Bad Hostname', 'False'),
+            ('HTTPS Expired Cert', 'False'),
+            ('HTTPS Self Signed Cert', 'False'),
+            ('HSTS', 'False'),
+            ('HSTS Header', ''),
+            ('HSTS Max Age', ''),
+            ('HSTS Entire Domain', 'False'),
+            ('HSTS Preload Ready', 'False'),
+            ('HSTS Preload Pending', 'False'),
+            ('HSTS Preloaded', 'False'),
+            ('Base Domain HSTS Preloaded', 'False'),
+            ('Domain Supports HTTPS', 'False'),
+            ('Domain Enforces HTTPS', 'False'),
+            ('Domain Uses Strong HSTS', 'False'),
+            ('Unknown Error', 'False'),
+        ]
 
-            self.assertEqual(content, expected)
+        header = ','.join(t[0] for t in domain_data)
+        values = ','.join(t[1] for t in domain_data)
+        expected = header + '\n' + values + '\n'
+        self.assertEqual(content, expected)
+
+        # Sanity check that this hard coded data has the same headers as defined
+        # in the package. This should never fail, as the above assert should
+        # catch any changes in the header columns.
+        self.assertEqual(header, ','.join(_pshtt.HEADERS))

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,59 @@
+import os
+import sys
+import tempfile
+import unittest
+
+from pshtt.models import Domain, Endpoint
+from pshtt import pshtt as _pshtt
+from pshtt.cli import to_csv
+
+
+class FakeSuffixList(object):
+    def get_public_suffix(self, hostname, *args, **kwargs):
+        return hostname
+
+
+# Artificially setup the the preload and suffix lists
+# This should be irrelevant after #126 is decided upon / merged
+_pshtt.suffix_list = FakeSuffixList()
+_pshtt.preload_list = []
+_pshtt.preload_pending = []
+
+
+class TestToCSV(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        base_domain = 'example.com'
+
+        domain = Domain(base_domain)
+        domain.http = Endpoint("http", "root", base_domain)
+        domain.httpwww = Endpoint("http", "www", base_domain)
+        domain.https = Endpoint("https", "root", base_domain)
+        domain.httpswww = Endpoint("https", "www", base_domain)
+
+        cls.results = _pshtt.result_for(domain)
+        cls.temp_filename = os.path.join(tempfile.gettempdir(), 'results.csv')
+
+    @unittest.skipIf(sys.version_info[0] < 3, 'Python 3 test only')
+    def test_no_results(self):
+        to_csv([], self.temp_filename)
+
+        with open(self.temp_filename) as fh:
+            content = fh.read()
+
+            expected = 'Domain,Base Domain,Canonical URL,Live,Redirect,Redirect To,Valid HTTPS,Defaults to HTTPS,Downgrades HTTPS,Strictly Forces HTTPS,HTTPS Bad Chain,HTTPS Bad Hostname,HTTPS Expired Cert,HTTPS Self Signed Cert,HSTS,HSTS Header,HSTS Max Age,HSTS Entire Domain,HSTS Preload Ready,HSTS Preload Pending,HSTS Preloaded,Base Domain HSTS Preloaded,Domain Supports HTTPS,Domain Enforces HTTPS,Domain Uses Strong HSTS,Unknown Error\n'
+
+            self.assertEqual(content, expected)
+
+    @unittest.skipIf(sys.version_info[0] < 3, 'Python 3 test only')
+    def test_single_result(self):
+        to_csv([self.results], self.temp_filename)
+
+        with open(self.temp_filename) as fh:
+            content = fh.read()
+
+            expected = ''
+            expected += 'Domain,Base Domain,Canonical URL,Live,Redirect,Redirect To,Valid HTTPS,Defaults to HTTPS,Downgrades HTTPS,Strictly Forces HTTPS,HTTPS Bad Chain,HTTPS Bad Hostname,HTTPS Expired Cert,HTTPS Self Signed Cert,HSTS,HSTS Header,HSTS Max Age,HSTS Entire Domain,HSTS Preload Ready,HSTS Preload Pending,HSTS Preloaded,Base Domain HSTS Preloaded,Domain Supports HTTPS,Domain Enforces HTTPS,Domain Uses Strong HSTS,Unknown Error\n'
+            expected += 'example.com,example.com,http://example.com,False,False,,False,False,False,False,False,False,False,False,False,,,False,False,False,False,False,False,False,False,False\n'
+
+            self.assertEqual(content, expected)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -14,7 +14,7 @@ class TestSmartOpen(unittest.TestCase):
     def test_with_empty_filename(self):
         """Should raise a `FileNotFoundError`"""
         with self.assertRaises(FileNotFoundError):
-            with smart_open('') as fh:
+            with smart_open(''):
                 pass
 
     def test_with_real_filename(self):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -11,12 +11,21 @@ class TestSmartOpen(unittest.TestCase):
         with smart_open() as fh:
             self.assertIs(fh, sys.stdout)
 
+    @unittest.skipIf(sys.version_info[0] < 3, 'Python 3 version of test')
     def test_with_empty_filename(self):
         """Should raise a `FileNotFoundError`"""
         with self.assertRaises(FileNotFoundError):
             with smart_open(''):
                 pass
 
+    @unittest.skipIf(sys.version_info[0] >= 3, 'Python 2 version of test')
+    def test_with_empty_filename_python2(self):
+        """Should raise a `FileNotFoundError`"""
+        with self.assertRaises(IOError):
+            with smart_open(''):
+                pass
+
+    @unittest.skipIf(sys.version_info[0] < 3, 'Python 3 version of test')
     def test_with_real_filename(self):
         test_data = 'This is the test data'
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,30 @@
+import os
+import sys
+import tempfile
+import unittest
+
+from pshtt.utils import smart_open
+
+
+class TestSmartOpen(unittest.TestCase):
+    def test_without_filename(self):
+        with smart_open() as fh:
+            self.assertIs(fh, sys.stdout)
+
+    def test_with_empty_filename(self):
+        """Should raise a `FileNotFoundError`"""
+        with self.assertRaises(FileNotFoundError):
+            with smart_open('') as fh:
+                pass
+
+    def test_with_real_filename(self):
+        test_data = 'This is the test data'
+
+        with tempfile.TemporaryDirectory() as tmp_dirname:
+            # Make a temporary file to use
+            filename = os.path.join(tmp_dirname, 'foo')
+
+            with smart_open(filename) as fh:
+                fh.write(test_data)
+
+            self.assertEqual(test_data, open(filename).read())

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -14,7 +14,7 @@ class TestSmartOpen(unittest.TestCase):
     @unittest.skipIf(sys.version_info[0] < 3, 'Python 3 version of test')
     def test_with_empty_filename(self):
         """Should raise a `FileNotFoundError`"""
-        with self.assertRaises(FileNotFoundError):
+        with self.assertRaises(FileNotFoundError):  # noqa
             with smart_open(''):
                 pass
 

--- a/tox.ini
+++ b/tox.ini
@@ -8,7 +8,7 @@ deps =
     pytest-cov
     pytest
     coveralls
-commands = pytest --cov=pshtt
+commands = pytest --cov={envsitepackagesdir}/pshtt
 
 [testenv:flake8]
 deps = flake8


### PR DESCRIPTION
This resolves #28, by re-working the cli main function to write out each domain of data as it is generated. This works by converting the `inspect_domains` function yield the results of each domain inspection as they occur, rather than waiting until the very end of the generation.

This PR also simplifies the logic surrounding writing out the other formats (JSON and MD) by using a unified `smart_open` context manager to manage outputting to a file vs to stdout.