### PR TITLE
Ignore a top level `venv/` directory from flake8

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,2 +1,3 @@
 [flake8]
 ignore = E501,F999
+exclude = venv


### PR DESCRIPTION
Should fix the issue reported by @jsf9k in https://github.com/dhs-ncats/pshtt/pull/125#issuecomment-338976454