### PR TITLE
Added pytablereader to setup.py and requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,7 @@ sslyze==1.1.0
 wget==3.2
 docopt
 requests_cache
+pytablereader
 pytablewriter
 publicsuffix
 pyopenssl==17.2.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,10 +1,1 @@
-requests>=2.18.4
-sslyze==1.1.0
-wget>=3.2
-docopt
-pytablereader
-pytablewriter
-publicsuffix
-pyopenssl==17.2.0
-tox
-pytest
+-e .[test]

--- a/setup.py
+++ b/setup.py
@@ -63,10 +63,19 @@ setup(
         'wget>=3.2',
         'docopt',
         'requests_cache',
+        'pytablereader',
         'pytablewriter',
         'publicsuffix',
         'pyopenssl>=17.2.0'
     ],
+
+    extras_require={
+        # 'dev': ['check-manifest'],
+        'test': [
+            'tox',
+            'pytest'
+        ],
+    },
 
     # Conveniently allows one to run the CLI tool as `pshtt`
     entry_points={


### PR DESCRIPTION
It appears to get installed automatically with python 3 but not with python 2.  I'm not entirely certain what is going on, but see for example https://travis-ci.org/dhs-ncats/pshtt/jobs/301761188.

Also added test requirements to setup.py