### PR TITLE
Modified Dockerfile for New Depedency Pipeline

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,16 @@
+*.egg-info
+cache
+.coverage
+gce-scripts
+.git
+.gitignore
+LICENSE.md
+mailer.egg-info
+README.md
+requirements.txt
+run
+tests
+.tox
+tox.ini
+.travis.yml
+venv

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,7 @@
-FROM python:3.5-onbuild
+FROM python:3.5.4
+
+COPY . /
+RUN pip install --no-cache-dir -r requirements.txt
 
 ENTRYPOINT ["./entrypoint.sh"]
 CMD ["--help"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,18 @@
-FROM python:3.5.4
+FROM python:3.6.3
 
-COPY . /
-RUN pip install --no-cache-dir -r requirements.txt
+# Create an unprivileged user
+ENV PSHTT_HOME=/home/pshtt
+RUN mkdir ${PSHTT_HOME} 
+RUN groupadd --system pshtt \
+    && useradd --system --comment="pshtt user" --gid="pshtt" pshtt
 
-ENTRYPOINT ["./entrypoint.sh"]
+# Install pshtt
+COPY . ${PSHTT_HOME}
+RUN chown -R pshtt:pshtt ${PSHTT_HOME}
+RUN pip install --no-cache ${PSHTT_HOME}
+
+# Prepare to run
+WORKDIR PSHTT_HOME
+USER pshtt:pshtt
+ENTRYPOINT ["pshtt"]
 CMD ["--help"]


### PR DESCRIPTION
The `python:3.5-onbuild` image tag triggers a bunch of steps that assume dependencies are written to `requirements.txt`.

This PR moves us to the latest minor version (3.5.4), and manually copies over files needed to build `pshtt`.