### PR TITLE
Version Pinning for "Operational" *master* Branch

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -58,21 +58,21 @@ setup(
     packages=['pshtt'],
 
     install_requires=[
-        'requests>=2.18.4',
-        'sslyze>=1.1.0',
-        'wget>=3.2',
-        'docopt',
-        'pytablereader',
-        'pytablewriter',
-        'publicsuffix',
-        'pyopenssl>=17.2.0'
+        'requests==2.18.4',
+        'sslyze==1.2.0',
+        'wget==3.2',
+        'docopt==0.6.2',
+        'pytablereader==0.15.0',
+        'pytablewriter==0.27.1',
+        'publicsuffix==1.1.0',
+        'pyopenssl==17.4.0'
     ],
 
     extras_require={
         # 'dev': ['check-manifest'],
         'test': [
-            'tox',
-            'pytest'
+            'tox==2.9.1',
+            'pytest==3.3.0'
         ],
     },
 


### PR DESCRIPTION
Given the recent trouble with our dependencies drifting in and out of compatability, I'm proposing we version pin *master* to a conservative, known-to-be-working set. I took a naive approach here and just `==` the latest versions of various components that I knew worked for my personal usage. There may be a more pythonic way of doing this, but I'm not super familiar with the idioms.