### PR TITLE
Reverting to the latest 1.3 version of sslyze.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -59,7 +59,7 @@ setup(
 
     install_requires=[
         'requests>=2.18.4',
-        'sslyze>=1.1.0',
+        'sslyze>=1.3.4,<1.4.0',
         'wget>=3.2',
         'docopt',
         'pytablereader',


### PR DESCRIPTION
The just-released 1.4 version seems to segfault, and it has a breaking API change.