### PR TITLE
Note the Python 3 requirement in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@
 
 ## Getting Started
 
+`pshtt` requires **Python 3.4+**. Python 2 is not supported.
+
 `pshtt` can be installed as a module, or run directly from the repository.
 
 #### Installed as a module


### PR DESCRIPTION
Following up on #159, which dropped Python 2 support (and/or noted that `sslyze` is [not supporting Python 2](https://github.com/nabla-c0d3/nassl/issues/34#issuecomment-375896876)), this notes the Python 3 support in the README.