### PR TITLE
Adds support for sslyze>=3.0.0

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -259,9 +259,6 @@ jobs:
           - "3.9"
           - "3.10"
           # - "3.11"
-        include:
-          - os: ubuntu-20.04
-            python-version: "3.6"
     steps:
       - uses: actions/checkout@v3
       - id: setup-python

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -112,24 +112,12 @@ jobs:
       matrix:
         os:
           - ubuntu-latest
-        # The versions of nassl pinned by our sslyze version constraint only
-        # have bdists available for Python 3.6 and 3.7, so we can only support
-        # those versions of Python. The error seen when trying to install on
-        # Python 3.8+ is:
-        # ERROR: Cannot install pshtt because these package versions have
-        # conflicting dependencies.
-        # The conflict is caused by:
-        #   sslyze 2.1.4 depends on nassl<2.3.0 and >=2.2.0
-        #   sslyze 2.1.3 depends on nassl<2.3.0 and >=2.2.0
         python-version:
           - "3.7"
-          # - "3.8"
-          # - "3.9"
-          # - "3.10"
+          - "3.8"
+          - "3.9"
+          - "3.10"
           # - "3.11"
-        include:
-          - os: ubuntu-20.04
-            python-version: "3.6"
     steps:
       - uses: actions/checkout@v3
       - id: setup-python
@@ -221,20 +209,10 @@ jobs:
           - ubuntu-latest
         python-version:
           - "3.7"
-          # Disabled due to an unresolvable dependency issue between sslyze and
-          # nassl:
-          # ERROR: Cannot install pshtt because these package versions have
-          # conflicting dependencies.
-          # The conflict is caused by:
-          #   sslyze 2.1.4 depends on nassl<2.3.0 and >=2.2.0
-          #   sslyze 2.1.3 depends on nassl<2.3.0 and >=2.2.0
-          # - "3.8"
-          # - "3.9"
-          # - "3.10"
+          - "3.8"
+          - "3.9"
+          - "3.10"
           # - "3.11"
-        include:
-          - os: ubuntu-20.04
-            python-version: "3.6"
     steps:
       - uses: actions/checkout@v3
       - id: setup-python

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,9 +23,7 @@ jobs:
       - id: setup-python
         uses: actions/setup-python@v4
         with:
-          # A lower version is used because of a dependency issue in Python
-          # versions 3.8-3.11
-          python-version: "3.7"
+          python-version: "3.10"
       # We need the Go version and Go cache location for the actions/cache step,
       # so the Go installation must happen before that.
       - id: setup-go
@@ -167,9 +165,7 @@ jobs:
       - id: setup-python
         uses: actions/setup-python@v4
         with:
-          # A lower version is used because of a dependency issue in Python
-          # versions 3.8-3.11
-          python-version: "3.7"
+          python-version: "3.10"
       - uses: actions/cache@v3
         env:
           BASE_CACHE_KEY: "${{ github.job }}-${{ runner.os }}-\
@@ -259,16 +255,9 @@ jobs:
           - ubuntu-latest
         python-version:
           - "3.7"
-          # Disabled due to an unresolvable dependency issue between sslyze and
-          # nassl:
-          # ERROR: Cannot install pshtt because these package versions have
-          # conflicting dependencies.
-          # The conflict is caused by:
-          #   sslyze 2.1.4 depends on nassl<2.3.0 and >=2.2.0
-          #   sslyze 2.1.3 depends on nassl<2.3.0 and >=2.2.0
-          # - "3.8"
-          # - "3.9"
-          # - "3.10"
+          - "3.8"
+          - "3.9"
+          - "3.10"
           # - "3.11"
         include:
           - os: ubuntu-20.04

--- a/setup.py
+++ b/setup.py
@@ -75,7 +75,6 @@ setup(
         # that you indicate whether you support Python 2, Python 3 or both.
         "Programming Language :: Python :: 3",
         "Programming Language :: Python :: 3 :: Only",
-        "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",

--- a/setup.py
+++ b/setup.py
@@ -77,16 +77,13 @@ setup(
         "Programming Language :: Python :: 3 :: Only",
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
-        # "Programming Language :: Python :: 3.8",
-        # "Programming Language :: Python :: 3.9",
-        # "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
         # "Programming Language :: Python :: 3.11",
         "Programming Language :: Python :: Implementation :: CPython",
     ],
-    # The versions of nassl pinned by our sslyze version constraint only have
-    # bdists available for cp36 and cp37 on PyPI so we can only support Python
-    # 3.6 and 3.7 at this time.
-    python_requires=">=3.6, <3.8",
+    python_requires=">=3.7",
     # What does your project relate to?
     keywords="https best practices",
     packages=find_packages(where="src"),
@@ -103,7 +100,7 @@ setup(
         "requests>=2.18.4",
         # This is necessary to support the python_requires kwarg
         "setuptools >= 24.2.0",
-        "sslyze>=3.0.0",
+        "sslyze>=3.0.0,<5.0.0",
         "wget>=3.2",
     ],
     extras_require={

--- a/setup.py
+++ b/setup.py
@@ -103,7 +103,7 @@ setup(
         "requests>=2.18.4",
         # This is necessary to support the python_requires kwarg
         "setuptools >= 24.2.0",
-        "sslyze>=2.1.3,<3.0.0",
+        "sslyze>=3.0.0",
         "wget>=3.2",
     ],
     extras_require={

--- a/src/pshtt/pshtt.py
+++ b/src/pshtt/pshtt.py
@@ -741,20 +741,66 @@ def https_check(endpoint):
             return
 
     try:
+        # Default endpoint assessments to False until proven True.
+        endpoint.https_expired_cert = False
+        endpoint.https_self_signed_cert = False
+        endpoint.https_bad_chain = False
+        endpoint.https_bad_hostname = False
+
+        # Default trust to Fase until proven True
         public_trust = True
         custom_trust = True
         public_not_trusted_names = []
-        validation_results = cert_plugin_result.certificate_deployments[0].path_validation_results
-        for result in validation_results:
-            if result.was_validation_successful:
-                # We're assuming that it is trusted to start with
-                pass
-            else:
-                if "Custom" in result.trust_store.name:
-                    custom_trust = False
+        for certificate_deployment in cert_plugin_result.certificate_deployments:
+            validation_results = certificate_deployment.path_validation_results
+            for result in validation_results:
+                if result.was_validation_successful:
+                    # We're assuming that it is trusted to start with
+                    pass
                 else:
-                    public_trust = False
-                    public_not_trusted_names.append(result.trust_store.name)
+                    if 'Custom' in result.trust_store.name:
+                        custom_trust = False
+                    else:
+                        public_trust = False
+                        public_not_trusted_names.append(result.trust_store.name)
+
+                if STORE in result.trust_store.name:
+                    cert_chain = result.verified_certificate_chain
+                    leaf_cert = cert_chain[0]
+
+                    # Check for leaf certificate expiration/self-signature.
+                    if leaf_cert.not_valid_after < datetime.datetime.now():
+                        endpoint.https_expired_cert = True
+
+                    # Check to see if the cert is self-signed
+                    if leaf_cert.issuer == leaf_cert.subject:
+                        endpoint.https_self_signed_cert = True
+
+                    # Check certificate chain till the second last element
+                    # The last cert being the root cert is self signed and
+                    # hence the self signed check is not valid
+                    # NOTE: If this is the only flag that's set, it's probably
+                    # an incomplete chain
+                    # If this isn't the only flag that is set, it might be
+                    # because there is another error. More debugging would
+                    # need to be done at this point, but not through sslyze
+                    # because sslyze doesn't have enough granularity
+                    for cert in cert_chain[:-1]:
+                        # Check for certificate expiration
+                        if cert.not_valid_after < datetime.datetime.now():
+                            endpoint.https_bad_chain = True
+
+                        # Check to see if the cert is self-signed
+                        if cert.issuer == cert.subject or not cert.issuer:
+                            endpoint.https_bad_chain = True
+
+                    # If leaf certificate subject does NOT match hostname, bad hostname
+                    # NOTE: Since sslyze 3.0.0, ever since JSON output for certinfo,
+                    # SAN(s) are checked as part of _certificate_matches_hostname which
+                    # called as part of leaf_certificate_subject_matches_hostname
+                    if not certificate_deployment.leaf_certificate_subject_matches_hostname:
+                        endpoint.https_bad_hostname = True
+
         if public_trust:
             logging.warning(
                 "%s: Publicly trusted by common trust stores.", endpoint.url
@@ -776,48 +822,15 @@ def https_check(endpoint):
         endpoint.https_custom_trusted = custom_trust
     except Exception as err:
         # Ignore exception
-        logging.exception("%s: Unknown exception examining trust.", endpoint.url)
-        utils.debug("%s: Unknown exception examining trust: %s", endpoint.url, err)
-
-    # Default endpoint assessments to False until proven True.
-    endpoint.https_expired_cert = False
-    endpoint.https_self_signed_cert = False
-    endpoint.https_bad_chain = False
-    endpoint.https_bad_hostname = False
-
-    cert_chain = cert_plugin_result.certificate_deployments[0].received_certificate_chain
-    leaf_cert = cert_chain[0]
-
-    # Check for leaf certificate expiration/self-signature.
-    if leaf_cert.not_valid_after < datetime.datetime.now():
-        endpoint.https_expired_cert = True
-
-    # Check to see if the cert is self-signed
-    if leaf_cert.issuer == leaf_cert.subject:
-        endpoint.https_self_signed_cert = True
-
-    # Check certificate chain
-    # NOTE: If this is the only flag that's set, it's probably
-    # an incomplete chain
-    # If this isn't the only flag that is set, it might be
-    # because there is another error. More debugging would
-    # need to be done at this point, but not through sslyze
-    # because sslyze doesn't have enough granularity
-    for cert in cert_chain[1:]:
-        # Check for certificate expiration
-        if cert.not_valid_after < datetime.datetime.now():
-            endpoint.https_bad_chain = True
-
-        # Check to see if the cert is self-signed
-        if cert.issuer == (cert.subject or None):
-            endpoint.https_bad_chain = True
-
-    # If leaf certificate subject does NOT match hostname, bad hostname
-    # NOTE: Since sslyze 3.0.0, ever since JSON output for certinfo,
-    # SAN(s) are checked as part of _certificate_matches_hostname which
-    # called as part of leaf_certificate_subject_matches_hostname
-    if not cert_plugin_result.certificate_deployments[0].leaf_certificate_subject_matches_hostname:
-        endpoint.https_bad_hostname = True
+        logging.exception(
+            "%s: Unknown exception examining certificate deployment.",
+            endpoint.url
+        )
+        utils.debug(
+            "%s: Unknown exception examining certificate deployment: %s",
+            endpoint.url,
+            err
+        )
 
     try:
         endpoint.https_cert_chain_len = len(cert_plugin_result.certificate_deployments[0].received_certificate_chain)
@@ -831,12 +844,12 @@ def https_check(endpoint):
             if cert_plugin_result.verified_certificate_chain is None:
                 logging.warning(
                     "%s: Untrusted certificate chain, probably due to missing intermediate certificate.",
-                    endpoint.url,
+                    endpoint.url
                 )
                 utils.debug(
-                    "%s: Only %d certificates in certificate chain received.",
+                    "%s: Only {} certificates in certificate chain received.",
                     endpoint.url,
-                    cert_plugin_result.received_certificate_chain.__len__(),
+                    cert_plugin_result.received_certificate_chain.__len__()
                 )
             elif custom_trust is True and public_trust is False:
                 # recheck public trust using custom public trust store with manually added intermediate certificates

--- a/src/pshtt/pshtt.py
+++ b/src/pshtt/pshtt.py
@@ -691,7 +691,7 @@ def https_check(endpoint):
         command = ScanCommand.CERTIFICATE_INFO
         if CA_FILE is not None:
             command_extra_args = {
-                ScanCommand.CERTIFICATE_INFO: CertificateInfoExtraArguments(custom_ca_file=Path(CA_FILE))
+                command: CertificateInfoExtraArguments(custom_ca_file=Path(CA_FILE))
             }
             scan_request = ServerScanRequest(
                 server_info=server_info,
@@ -714,7 +714,7 @@ def https_check(endpoint):
                     "%s: Retrying sslyze scanner certificate plugin.", endpoint.url
                 )
                 scanner.queue_scan(scan_request)
-                # Retrieve results from generator object
+                # Consume the generator object and retrieve the first result
                 scan_result = [x for x in scanner.get_results()][0]
                 cert_plugin_result = scan_result.scan_commands_results[ScanCommand.CERTIFICATE_INFO]
             else:
@@ -793,7 +793,7 @@ def https_check(endpoint):
         endpoint.https_expired_cert = True
 
     # Check to see if the cert is self-signed
-    if leaf_cert.issuer is leaf_cert.subject:
+    if leaf_cert.issuer == leaf_cert.subject:
         endpoint.https_self_signed_cert = True
 
     # Check certificate chain
@@ -809,7 +809,7 @@ def https_check(endpoint):
             endpoint.https_bad_chain = True
 
         # Check to see if the cert is self-signed
-        if cert.issuer is (cert.subject or None):
+        if cert.issuer == (cert.subject or None):
             endpoint.https_bad_chain = True
 
     # If leaf certificate subject does NOT match hostname, bad hostname
@@ -823,7 +823,7 @@ def https_check(endpoint):
         endpoint.https_cert_chain_len = len(cert_plugin_result.certificate_deployments[0].received_certificate_chain)
         if (
                 endpoint.https_self_signed_cert is False and (
-                    len(cert_plugin_result.certificate_deployments[0].received_certificate_chain) < 2
+                    endpoint.https_cert_chain_len < 2
                 )
         ):
             # *** TODO check that it is not a bad hostname and that the root cert is trusted before suggesting that it is an intermediate cert issue.
@@ -846,7 +846,7 @@ def https_check(endpoint):
                         scanner = Scanner()
                         command = ScanCommand.CERTIFICATE_INFO
                         command_extra_args = {
-                            ScanCommand.CERTIFICATE_INFO: CertificateInfoExtraArguments(
+                            command: CertificateInfoExtraArguments(
                                     custom_ca_file=Path(PT_INT_CA_FILE)
                                 )
                         }
@@ -856,7 +856,7 @@ def https_check(endpoint):
                             scan_commands=[command]
                         )
                         scanner.queue_scan(scan_request)
-                        # Retrieve results from generator object
+                        # Consume the generator object and retrieve the first result
                         scan_result = [x for x in scanner.get_results()][0]
                         cert_plugin_result = scan_result.scan_commands_results[ScanCommand.CERTIFICATE_INFO]
                         if cert_plugin_result.certificate_deployments[0].verified_certificate_chain is not None:

--- a/src/pshtt/pshtt.py
+++ b/src/pshtt/pshtt.py
@@ -799,7 +799,7 @@ def https_check(endpoint):
     # Check certificate chain
     # NOTE: If this is the only flag that's set, it's probably
     # an incomplete chain
-    # If this isnt the only flag that is set, it's might be
+    # If this isn't the only flag that is set, it might be
     # because there is another error. More debugging would
     # need to be done at this point, but not through sslyze
     # because sslyze doesn't have enough granularity

--- a/src/pshtt/pshtt.py
+++ b/src/pshtt/pshtt.py
@@ -673,7 +673,7 @@ def https_check(endpoint):
         logging.exception(
             "%s: Error in sslyze server connectivity check when connecting to %s",
             endpoint.url,
-            err.server_info.hostname,
+            err.server_location.hostname,
         )
         utils.debug("%s: %s", endpoint.url, err)
         return
@@ -833,7 +833,9 @@ def https_check(endpoint):
         )
 
     try:
-        endpoint.https_cert_chain_len = len(cert_plugin_result.certificate_deployments[0].received_certificate_chain)
+        endpoint.https_cert_chain_len = 0
+        for certificate_deployment in cert_plugin_result.certificate_deployments:
+            endpoint.https_cert_chain_len += len(certificate_deployment.received_certificate_chain)
         if (
                 endpoint.https_self_signed_cert is False and (
                     endpoint.https_cert_chain_len < 2
@@ -841,15 +843,19 @@ def https_check(endpoint):
         ):
             # *** TODO check that it is not a bad hostname and that the root cert is trusted before suggesting that it is an intermediate cert issue.
             endpoint.https_missing_intermediate_cert = True
-            if cert_plugin_result.verified_certificate_chain is None:
+            has_verfied_cert_chain = True
+            for certificate_deployment in cert_plugin_result.certificate_deployments:
+                if certificate_deployment.verified_certificate_chain is None:
+                    has_verfied_cert_chain = False
+            if not has_verfied_cert_chain:
                 logging.warning(
                     "%s: Untrusted certificate chain, probably due to missing intermediate certificate.",
                     endpoint.url
                 )
                 utils.debug(
-                    "%s: Only {} certificates in certificate chain received.",
+                    "%s: Only %s certificates in certificate chain received.",
                     endpoint.url,
-                    cert_plugin_result.received_certificate_chain.__len__()
+                    endpoint.https_cert_chain_len
                 )
             elif custom_trust is True and public_trust is False:
                 # recheck public trust using custom public trust store with manually added intermediate certificates
@@ -872,7 +878,11 @@ def https_check(endpoint):
                         # Consume the generator object and retrieve the first result
                         scan_result = [x for x in scanner.get_results()][0]
                         cert_plugin_result = scan_result.scan_commands_results[ScanCommand.CERTIFICATE_INFO]
-                        if cert_plugin_result.certificate_deployments[0].verified_certificate_chain is not None:
+                        has_verfied_cert_chain = True
+                        for certificate_deployment in cert_plugin_result.certificate_deployments:
+                            if certificate_deployment.verified_certificate_chain is None:
+                                has_verfied_cert_chain = False
+                        if has_verfied_cert_chain:
                             public_trust = True
                             endpoint.https_public_trusted = public_trust
                             logging.warning(

--- a/src/pshtt/pshtt.py
+++ b/src/pshtt/pshtt.py
@@ -7,6 +7,7 @@ import datetime
 import json
 import logging
 import os
+from pathlib import Path  # Python3
 import re
 import sys
 from urllib import parse as urlparse
@@ -16,8 +17,6 @@ import OpenSSL
 from publicsuffixlist.compat import PublicSuffixList  # type: ignore
 from publicsuffixlist.update import updatePSL  # type: ignore
 import requests
-
-from pathlib import Path  # Python3
 from sslyze import (  # type: ignore
     Scanner,
     ServerConnectivityTester,
@@ -25,13 +24,14 @@ from sslyze import (  # type: ignore
     ServerScanRequest,
 )
 from sslyze.errors import ConnectionToServerFailed  # type: ignore
+from sslyze.plugins.certificate_info.implementation import (  # type: ignore
+    CertificateInfoExtraArguments,
+)
 from sslyze.plugins.scan_commands import ScanCommand  # type: ignore
-from sslyze.plugins.certificate_info.implementation import CertificateInfoExtraArguments  # type: ignore
 import urllib3
 
 from . import utils
 from .models import Domain, Endpoint
-
 
 # We're going to be making requests with certificate validation
 # disabled.  Commented next line due to pylint warning that urllib3 is
@@ -648,8 +648,10 @@ def https_check(endpoint):
     # remove the https:// from prefix for sslyze
     try:
         hostname = endpoint.url[8:]
-        server_location = ServerNetworkLocationViaDirectConnection.with_ip_address_lookup(
-            hostname=hostname, port=443
+        server_location = (
+            ServerNetworkLocationViaDirectConnection.with_ip_address_lookup(
+                hostname=hostname, port=443
+            )
         )
         server_tester = ServerConnectivityTester()
         server_info = server_tester.perform(server_location)
@@ -659,12 +661,13 @@ def https_check(endpoint):
             endpoint.ip = ip
         else:
             if endpoint.ip != ip:
-                utils.debug("%s: Endpoint IP is already %s, but requests IP is %s.",
+                utils.debug(
+                    "%s: Endpoint IP is already %s, but requests IP is %s.",
                     endpoint.url,
                     endpoint.ip,
-                    ip
+                    ip,
                 )
-        if server_info.tls_probing_result.client_auth_requirement.name == 'REQUIRED':
+        if server_info.tls_probing_result.client_auth_requirement.name == "REQUIRED":
             endpoint.https_client_auth_required = True
             logging.warning("%s: Client Authentication REQUIRED", endpoint.url)
     except ConnectionToServerFailed as err:
@@ -696,17 +699,18 @@ def https_check(endpoint):
             scan_request = ServerScanRequest(
                 server_info=server_info,
                 scan_commands_extra_arguments=command_extra_args,
-                scan_commands=[command]
+                scan_commands=[command],
             )
         else:
             scan_request = ServerScanRequest(
-                server_info=server_info,
-                scan_commands=[command]
+                server_info=server_info, scan_commands=[command]
             )
         scanner.queue_scan(scan_request)
         # Retrieve results from generator object
         scan_result = [x for x in scanner.get_results()][0]
-        cert_plugin_result = scan_result.scan_commands_results[ScanCommand.CERTIFICATE_INFO]
+        cert_plugin_result = scan_result.scan_commands_results[
+            ScanCommand.CERTIFICATE_INFO
+        ]
     except Exception as err:
         try:
             if "timed out" in str(err):
@@ -716,7 +720,9 @@ def https_check(endpoint):
                 scanner.queue_scan(scan_request)
                 # Consume the generator object and retrieve the first result
                 scan_result = [x for x in scanner.get_results()][0]
-                cert_plugin_result = scan_result.scan_commands_results[ScanCommand.CERTIFICATE_INFO]
+                cert_plugin_result = scan_result.scan_commands_results[
+                    ScanCommand.CERTIFICATE_INFO
+                ]
             else:
                 logging.exception(
                     "%s: Unknown exception in sslyze scanner certificate plugin.",
@@ -758,7 +764,7 @@ def https_check(endpoint):
                     # We're assuming that it is trusted to start with
                     pass
                 else:
-                    if 'Custom' in result.trust_store.name:
+                    if "Custom" in result.trust_store.name:
                         custom_trust = False
                     else:
                         public_trust = False
@@ -798,7 +804,9 @@ def https_check(endpoint):
                     # NOTE: Since sslyze 3.0.0, ever since JSON output for certinfo,
                     # SAN(s) are checked as part of _certificate_matches_hostname which
                     # called as part of leaf_certificate_subject_matches_hostname
-                    if not certificate_deployment.leaf_certificate_subject_matches_hostname:
+                    if (
+                        not certificate_deployment.leaf_certificate_subject_matches_hostname
+                    ):
                         endpoint.https_bad_hostname = True
 
         if public_trust:
@@ -823,23 +831,22 @@ def https_check(endpoint):
     except Exception as err:
         # Ignore exception
         logging.exception(
-            "%s: Unknown exception examining certificate deployment.",
-            endpoint.url
+            "%s: Unknown exception examining certificate deployment.", endpoint.url
         )
         utils.debug(
             "%s: Unknown exception examining certificate deployment: %s",
             endpoint.url,
-            err
+            err,
         )
 
     try:
         endpoint.https_cert_chain_len = 0
         for certificate_deployment in cert_plugin_result.certificate_deployments:
-            endpoint.https_cert_chain_len += len(certificate_deployment.received_certificate_chain)
-        if (
-                endpoint.https_self_signed_cert is False and (
-                    endpoint.https_cert_chain_len < 2
-                )
+            endpoint.https_cert_chain_len += len(
+                certificate_deployment.received_certificate_chain
+            )
+        if endpoint.https_self_signed_cert is False and (
+            endpoint.https_cert_chain_len < 2
         ):
             # *** TODO check that it is not a bad hostname and that the root cert is trusted before suggesting that it is an intermediate cert issue.
             endpoint.https_missing_intermediate_cert = True
@@ -850,12 +857,12 @@ def https_check(endpoint):
             if not has_verfied_cert_chain:
                 logging.warning(
                     "%s: Untrusted certificate chain, probably due to missing intermediate certificate.",
-                    endpoint.url
+                    endpoint.url,
                 )
                 utils.debug(
                     "%s: Only %s certificates in certificate chain received.",
                     endpoint.url,
-                    endpoint.https_cert_chain_len
+                    endpoint.https_cert_chain_len,
                 )
             elif custom_trust is True and public_trust is False:
                 # recheck public trust using custom public trust store with manually added intermediate certificates
@@ -866,21 +873,28 @@ def https_check(endpoint):
                         command = ScanCommand.CERTIFICATE_INFO
                         command_extra_args = {
                             command: CertificateInfoExtraArguments(
-                                    custom_ca_file=Path(PT_INT_CA_FILE)
-                                )
+                                custom_ca_file=Path(PT_INT_CA_FILE)
+                            )
                         }
                         scan_request = ServerScanRequest(
                             server_info=server_info,
                             scan_commands_extra_arguments=command_extra_args,
-                            scan_commands=[command]
+                            scan_commands=[command],
                         )
                         scanner.queue_scan(scan_request)
                         # Consume the generator object and retrieve the first result
                         scan_result = [x for x in scanner.get_results()][0]
-                        cert_plugin_result = scan_result.scan_commands_results[ScanCommand.CERTIFICATE_INFO]
+                        cert_plugin_result = scan_result.scan_commands_results[
+                            ScanCommand.CERTIFICATE_INFO
+                        ]
                         has_verfied_cert_chain = True
-                        for certificate_deployment in cert_plugin_result.certificate_deployments:
-                            if certificate_deployment.verified_certificate_chain is None:
+                        for (
+                            certificate_deployment
+                        ) in cert_plugin_result.certificate_deployments:
+                            if (
+                                certificate_deployment.verified_certificate_chain
+                                is None
+                            ):
                                 has_verfied_cert_chain = False
                         if has_verfied_cert_chain:
                             public_trust = True


### PR DESCRIPTION
Updates the https_check function to use code that works with sslyze>=3.0.0

- fixes import errors for the current required modules
- uses the new format for certificate analyzer
- updates dependency of sslyze to >=3.0.0

Refs: #209 

Also, thanks to [Ethan](https://github.com/Ethanljf)'s [code snippet](https://github.com/cisagov/pshtt/issues/209#issue-591146621) that helped in this commit.

## 🧪 Testing ##

Tested the code using the current test suite of pshtt in debian 10, with python 3.7
Following is the command I ran: `python3 -m pytest`

## ✅ Checklist ##

* [x] This PR has an informative and human-readable title.
* [x] Changes are limited to a single goal - _eschew scope creep!_
* [x] All relevant type-of-change labels have been added.
* [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
* [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
* [x] All new and existing tests pass.
