### PR TITLE
Fix broken preload URL

### DIFF
--- a/src/pshtt/_version.py
+++ b/src/pshtt/_version.py
@@ -1,2 +1,2 @@
 """This file defines the version of this module."""
-__version__ = "0.6.9-rc.1"
+__version__ = "0.6.9"

--- a/src/pshtt/_version.py
+++ b/src/pshtt/_version.py
@@ -1,2 +1,2 @@
 """This file defines the version of this module."""
-__version__ = "0.6.9"
+__version__ = "0.6.9-rc.1"

--- a/src/pshtt/_version.py
+++ b/src/pshtt/_version.py
@@ -1,2 +1,2 @@
 """This file defines the version of this module."""
-__version__ = "0.6.8"
+__version__ = "0.6.9"

--- a/src/pshtt/pshtt.py
+++ b/src/pshtt/pshtt.py
@@ -1562,7 +1562,7 @@ def load_preload_list():
     utils.debug("Fetching Chrome preload list from source...", divider=True)
 
     # Downloads the chromium preloaded domain list and sets it to a global set
-    file_url = "https://chromium.googlesource.com/chromium/src/net/+/master/http/transport_security_state_static.json?format=TEXT"
+    file_url = "https://chromium.googlesource.com/chromium/src/net/+/main/http/transport_security_state_static.json?format=TEXT"
 
     try:
         request = requests.get(file_url)

--- a/src/pshtt/pshtt.py
+++ b/src/pshtt/pshtt.py
@@ -1562,7 +1562,7 @@ def load_preload_list():
     utils.debug("Fetching Chrome preload list from source...", divider=True)
 
     # Downloads the chromium preloaded domain list and sets it to a global set
-    file_url = "https://chromium.googlesource.com/chromium/src/net/+/main/http/transport_security_state_static.json?format=TEXT"
+    file_url = "https://chromium.googlesource.com/chromium/src/+/main/net/http/transport_security_state_static.json?format=TEXT"
 
     try:
         request = requests.get(file_url)


### PR DESCRIPTION
## 🗣 Description ##

This pull request fixes a broken URL pointing to the Chromium HSTS preloaded domain list.

## 💭 Motivation and context ##

The location of this data has changed upstream, and this is breaking the BOD 18-01 scanning.

Required to resolve cisagov/scanner#67.

## 🧪 Testing ##

All automated testing that is expected to pass passes.  The Python 3.6 tests fail because Python 3.6 is no longer supported by GitHub Actions.

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.

## ✅ Pre-merge checklist ##

- [x] Finalize version.

## ✅ Post-merge checklist ##

- [x] Create a release.
- [x] Push to [PyPI.org](https://pypi.org/project/pshtt/).
