### PR TITLE
Switch helper package for the Public Suffix List

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -94,7 +94,7 @@ setup(
     py_modules=[splitext(basename(path))[0] for path in glob("src/*.py")],
     install_requires=[
         "docopt>=0.6.2",
-        "publicsuffix>=1.1.0",
+        "publicsuffixlist[update]>=0.9.2 ",
         "pyopenssl>=17.5.0",
         "pytablereader>=0.15.0",
         "pytablewriter>=0.27.2",

--- a/src/pshtt/_version.py
+++ b/src/pshtt/_version.py
@@ -1,2 +1,2 @@
 """This file defines the version of this module."""
-__version__ = "0.6.9"
+__version__ = "0.6.10"

--- a/src/pshtt/_version.py
+++ b/src/pshtt/_version.py
@@ -1,2 +1,2 @@
 """This file defines the version of this module."""
-__version__ = "0.6.10-rc.1"
+__version__ = "0.6.10"

--- a/src/pshtt/_version.py
+++ b/src/pshtt/_version.py
@@ -1,2 +1,2 @@
 """This file defines the version of this module."""
-__version__ = "0.6.10"
+__version__ = "0.6.10-rc.1"

--- a/src/pshtt/pshtt.py
+++ b/src/pshtt/pshtt.py
@@ -1611,7 +1611,7 @@ def load_suffix_list(cache_suffix_list=None, update_list=False):
 
     # Use the local copy
     if cache_suffix_list:
-        utils.debug("Using cached Chrome preload list.", divider=True)
+        utils.debug("Using cached Public Suffix List.", divider=True)
         with codecs.open(cache_suffix_list, encoding="utf-8") as cache_file:
             suffixes = PublicSuffixList(cache_file)
     # Use the built-in copy

--- a/src/pshtt/pshtt.py
+++ b/src/pshtt/pshtt.py
@@ -9,13 +9,11 @@ import os
 import re
 import sys
 from urllib import parse as urlparse
-from urllib.error import URLError
 
 # Third-Party Libraries
 import OpenSSL
-
-# Unable to find type stubs for the publicsuffix package.
-from publicsuffix import PublicSuffixList, fetch  # type: ignore
+from publicsuffixlist.compat import PublicSuffixList  # type: ignore
+from publicsuffixlist.update import updatePSL  # type: ignore
 import requests
 
 # Unable to find type stubs for the sslyze package.
@@ -1594,21 +1592,33 @@ def load_preload_list():
     return fully_preloaded
 
 
-# Returns an instantiated PublicSuffixList object, and the
-# list of lines read from the file.
-def load_suffix_list():
+# Returns an instantiated PublicSuffixList object.
+def load_suffix_list(cache_suffix_list=None, update_list=False):
     """Download and load the public suffix list."""
-    # File does not exist, download current list and cache it at given location.
-    utils.debug("Downloading the Public Suffix List...", divider=True)
-    try:
-        cache_file = fetch()
-    except URLError as err:
-        logging.exception("Unable to download the Public Suffix List...")
-        utils.debug(err)
-        return []
-    content = cache_file.readlines()
-    suffixes = PublicSuffixList(content)
-    return suffixes, content
+    if update_list:
+        utils.debug("Downloading the Public Suffix List...", divider=True)
+        try:
+            # Update the local copy
+            if cache_suffix_list:
+                updatePSL(cache_suffix_list)
+            # Update the built-in copy
+            else:
+                updatePSL()
+        except Exception as err:
+            logging.exception("Unable to download the Public Suffix List...")
+            utils.debug(err)
+            return None
+
+    # Use the local copy
+    if cache_suffix_list:
+        utils.debug("Using cached Chrome preload list.", divider=True)
+        with codecs.open(cache_suffix_list, encoding="utf-8") as cache_file:
+            suffixes = PublicSuffixList(cache_file)
+    # Use the built-in copy
+    else:
+        suffixes = PublicSuffixList()
+
+    return suffixes
 
 
 def initialize_external_data(
@@ -1696,18 +1706,14 @@ def initialize_external_data(
 
     # Load Mozilla's current Public Suffix list.
     if SUFFIX_LIST is None:
-        if cache_suffix_list and os.path.exists(cache_suffix_list):
-            utils.debug("Using cached suffix list.", divider=True)
-            with codecs.open(cache_suffix_list, encoding="utf-8") as cache_file:
-                SUFFIX_LIST = PublicSuffixList(cache_file)
+        if cache_suffix_list:
+            # Retrieve the list if the path does not exist otherwise use the cached copy
+            SUFFIX_LIST = load_suffix_list(
+                cache_suffix_list, not os.path.exists(cache_suffix_list)
+            )
         else:
-            SUFFIX_LIST, raw_content = load_suffix_list()
-
-            if cache_suffix_list:
-                utils.debug(
-                    "Caching suffix list at %s", cache_suffix_list, divider=True
-                )
-                utils.write("".join(raw_content), cache_suffix_list)
+            # Load the built-in PSL
+            SUFFIX_LIST = load_suffix_list()
 
 
 def inspect_domains(domains, options):


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

This pull request switches [Public Suffix List] helper packages from [publicsuffix] to [publicsuffixlist]. Any necessary supporting changes are also made.
<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

The [publicsuffix] package is deprecated and has not been maintained for years. It finally reached a breaking point during this past weekend's BOD 18-01 scanning run where the server hosting the maintained public suffix list no longer returned the `charset` header that [publicsuffix] expects. The [publicsuffixlist] package is the currently maintained one of the two alternatives mentioned by [publicsuffix] and it has a compatibility layer for existing code that uses [publicsuffix].
<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🔔 See also ##

- https://github.com/cisagov/trustymail/pull/128
- https://github.com/cisagov/domain-scan/pull/2

## 🧪 Testing ##

Automated tests pass. I confirmed that I was able to perform a local scan using this branch.
<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.

## ✅ Pre-merge checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- These boxes should remain unchecked until the pull request has been approved. -->

- [x] Finalize version.

## ✅ Post-merge checklist ##

<!-- Remove any of the following that do not apply. -->

- [x] Create a release.

[Public Suffix List]: https://publicsuffix.org/
[publicsuffix]: https://pypi.org/project/publicsuffix/
[publicsuffixlist]: https://pypi.org/project/publicsuffixlist