### PR TITLE
Honor explicit ports in HTTPS checks

### DIFF
--- a/src/pshtt/_version.py
+++ b/src/pshtt/_version.py
@@ -1,3 +1,3 @@
 """This file defines the version of this module."""
 
-__version__ = "0.7.3"
+__version__ = "0.7.4"

--- a/src/pshtt/pshtt.py
+++ b/src/pshtt/pshtt.py
@@ -654,12 +654,21 @@ def https_check(endpoint):
     """Use sslyze to figure out the reason an endpoint failed to verify."""
     utils.debug("sslyzing %s...", endpoint.url)
 
-    # remove the https:// from prefix for sslyze
+    # Parse endpoint URL so explicit non-default ports are preserved.
     try:
-        hostname = endpoint.url[8:]
+        parsed_url = urlparse.urlparse(endpoint.url)
+        hostname = parsed_url.hostname
+        port = parsed_url.port
+
+        if hostname is None:
+            raise ValueError(f"Unable to parse hostname from URL: {endpoint.url}")
+
+        if port is None:
+            port = 443 if parsed_url.scheme == "https" else 80
+
         server_location = (
             ServerNetworkLocationViaDirectConnection.with_ip_address_lookup(
-                hostname=hostname, port=443
+                hostname=hostname, port=port
             )
         )
         server_tester = ServerConnectivityTester()

--- a/tests/test_pshtt.py
+++ b/tests/test_pshtt.py
@@ -101,7 +101,9 @@ class TestHttpsCheckServerLocation(unittest.TestCase):
 
         server_location = MagicMock()
         server_location.ip_address = "127.0.0.1"
-        mock_server_network_location.with_ip_address_lookup.return_value = server_location
+        mock_server_network_location.with_ip_address_lookup.return_value = (
+            server_location
+        )
 
         tester = MagicMock()
         tester.perform.side_effect = RuntimeError("stop after checking location args")
@@ -123,7 +125,9 @@ class TestHttpsCheckServerLocation(unittest.TestCase):
 
         server_location = MagicMock()
         server_location.ip_address = "127.0.0.1"
-        mock_server_network_location.with_ip_address_lookup.return_value = server_location
+        mock_server_network_location.with_ip_address_lookup.return_value = (
+            server_location
+        )
 
         tester = MagicMock()
         tester.perform.side_effect = RuntimeError("stop after checking location args")

--- a/tests/test_pshtt.py
+++ b/tests/test_pshtt.py
@@ -109,7 +109,12 @@ class TestHttpsCheckServerLocation(unittest.TestCase):
         tester.perform.side_effect = RuntimeError("stop after checking location args")
         mock_server_connectivity_tester.return_value = tester
 
-        https_check(endpoint)
+        # We stop the scan early by raising from perform(); https_check catches
+        # that and logs it via logging.exception, which would otherwise dump a
+        # traceback into the test output and look like a failure. Capture the
+        # expected error log so the output stays clean.
+        with self.assertLogs(level="ERROR"):
+            https_check(endpoint)
 
         mock_server_network_location.with_ip_address_lookup.assert_called_once_with(
             hostname="example.com", port=9443
@@ -133,7 +138,12 @@ class TestHttpsCheckServerLocation(unittest.TestCase):
         tester.perform.side_effect = RuntimeError("stop after checking location args")
         mock_server_connectivity_tester.return_value = tester
 
-        https_check(endpoint)
+        # We stop the scan early by raising from perform(); https_check catches
+        # that and logs it via logging.exception, which would otherwise dump a
+        # traceback into the test output and look like a failure. Capture the
+        # expected error log so the output stays clean.
+        with self.assertLogs(level="ERROR"):
+            https_check(endpoint)
 
         mock_server_network_location.with_ip_address_lookup.assert_called_once_with(
             hostname="example.com", port=443

--- a/tests/test_pshtt.py
+++ b/tests/test_pshtt.py
@@ -2,10 +2,11 @@
 
 # Standard Python Libraries
 import unittest
+from unittest.mock import MagicMock, patch
 
 # cisagov Libraries
 from pshtt.models import Domain, Endpoint
-from pshtt.pshtt import is_live
+from pshtt.pshtt import https_check, is_live
 
 
 class TestLiveliness(unittest.TestCase):
@@ -85,3 +86,51 @@ class TestLiveliness(unittest.TestCase):
         self.domain.httpswww.live = True
 
         self.assertTrue(is_live(self.domain))
+
+
+class TestHttpsCheckServerLocation(unittest.TestCase):
+    """Test HTTPS check parses endpoint host/port correctly for sslyze."""
+
+    @patch("pshtt.pshtt.ServerConnectivityTester")
+    @patch("pshtt.pshtt.ServerNetworkLocationViaDirectConnection")
+    def test_https_check_uses_explicit_port(
+        self, mock_server_network_location, mock_server_connectivity_tester
+    ):
+        """Use the endpoint's explicit port when building sslyze target."""
+        endpoint = Endpoint("https", "root", "example.com:9443")
+
+        server_location = MagicMock()
+        server_location.ip_address = "127.0.0.1"
+        mock_server_network_location.with_ip_address_lookup.return_value = server_location
+
+        tester = MagicMock()
+        tester.perform.side_effect = RuntimeError("stop after checking location args")
+        mock_server_connectivity_tester.return_value = tester
+
+        https_check(endpoint)
+
+        mock_server_network_location.with_ip_address_lookup.assert_called_once_with(
+            hostname="example.com", port=9443
+        )
+
+    @patch("pshtt.pshtt.ServerConnectivityTester")
+    @patch("pshtt.pshtt.ServerNetworkLocationViaDirectConnection")
+    def test_https_check_defaults_to_port_443(
+        self, mock_server_network_location, mock_server_connectivity_tester
+    ):
+        """Default to port 443 when endpoint URL has no explicit port."""
+        endpoint = Endpoint("https", "root", "example.com")
+
+        server_location = MagicMock()
+        server_location.ip_address = "127.0.0.1"
+        mock_server_network_location.with_ip_address_lookup.return_value = server_location
+
+        tester = MagicMock()
+        tester.perform.side_effect = RuntimeError("stop after checking location args")
+        mock_server_connectivity_tester.return_value = tester
+
+        https_check(endpoint)
+
+        mock_server_network_location.with_ip_address_lookup.assert_called_once_with(
+            hostname="example.com", port=443
+        )


### PR DESCRIPTION
Fixes #254

This came from https_check always building the SSLyze target with port 443 after slicing the URL string. If someone scans `domain:9443`, the port was not handled correctly and cert trust or chain fields ended up null.

This updates target parsing to use `urlparse` and pass the parsed host plus parsed port to SSLyze. When no explicit port is present, it still defaults to 443.

I also added unit tests that assert calls to `with_ip_address_lookup` for:
- `example.com:9443` -> host `example.com`, port `9443`
- `example.com` -> host `example.com`, port `443`

I could not run `pytest` end-to-end in this local environment because the `nassl` binary fails to load (`_SSLv2_method` symbol issue on macOS toolchain). I still verified changes by compiling modified files and running a targeted Python harness with stubbed SSLyze modules to validate host and port parsing.