### PR TITLE
Add test for HTTP default port 80 in https_check

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -95,6 +95,7 @@ test = [
     "pre-commit",
     "pytest-cov",
     "pytest",
+    "unittest-parametrize",
 ]
 
 [project.scripts]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -159,6 +159,12 @@ import_heading_firstparty = "cisagov Libraries"
 # linting
 profile = "black"
 
+[[tool.mypy.overrides]]
+# This library contains a py.typed file but that doesn't appear to be
+# sufficient for mypy.
+module = "unittest_parametrize"
+ignore_missing_imports = true
+
 [tool.pytest.ini_options]
 # Increase verbosity, display extra test summary info for tests that
 # did not pass, display code coverage results, and enable debug

--- a/tests/test_pshtt.py
+++ b/tests/test_pshtt.py
@@ -148,3 +148,32 @@ class TestHttpsCheckServerLocation(unittest.TestCase):
         mock_server_network_location.with_ip_address_lookup.assert_called_once_with(
             hostname="example.com", port=443
         )
+
+    @patch("pshtt.pshtt.ServerConnectivityTester")
+    @patch("pshtt.pshtt.ServerNetworkLocationViaDirectConnection")
+    def test_http_check_defaults_to_port_80(
+        self, mock_server_network_location, mock_server_connectivity_tester
+    ):
+        """Default to port 80 when an http endpoint URL has no explicit port."""
+        endpoint = Endpoint("http", "root", "example.com")
+
+        server_location = MagicMock()
+        server_location.ip_address = "127.0.0.1"
+        mock_server_network_location.with_ip_address_lookup.return_value = (
+            server_location
+        )
+
+        tester = MagicMock()
+        tester.perform.side_effect = RuntimeError("stop after checking location args")
+        mock_server_connectivity_tester.return_value = tester
+
+        # We stop the scan early by raising from perform(); https_check catches
+        # that and logs it via logging.exception, which would otherwise dump a
+        # traceback into the test output and look like a failure. Capture the
+        # expected error log so the output stays clean.
+        with self.assertLogs(level="ERROR"):
+            https_check(endpoint)
+
+        mock_server_network_location.with_ip_address_lookup.assert_called_once_with(
+            hostname="example.com", port=80
+        )

--- a/tests/test_pshtt.py
+++ b/tests/test_pshtt.py
@@ -132,7 +132,7 @@ class TestHttpsCheckServerLocation(ParametrizedTestCase):
     )
     @patch("pshtt.pshtt.ServerConnectivityTester")
     @patch("pshtt.pshtt.ServerNetworkLocationViaDirectConnection")
-    def test_https_check_default_ports(
+    def test_check_default_web_ports(
         self,
         mock_server_network_location,
         mock_server_connectivity_tester,

--- a/tests/test_pshtt.py
+++ b/tests/test_pshtt.py
@@ -4,6 +4,9 @@
 import unittest
 from unittest.mock import MagicMock, patch
 
+# Third-Party Libraries
+from unittest_parametrize import ParametrizedTestCase, param, parametrize
+
 # cisagov Libraries
 from pshtt.models import Domain, Endpoint
 from pshtt.pshtt import https_check, is_live
@@ -88,7 +91,7 @@ class TestLiveliness(unittest.TestCase):
         self.assertTrue(is_live(self.domain))
 
 
-class TestHttpsCheckServerLocation(unittest.TestCase):
+class TestHttpsCheckServerLocation(ParametrizedTestCase):
     """Test HTTPS check parses endpoint host/port correctly for sslyze."""
 
     @patch("pshtt.pshtt.ServerConnectivityTester")
@@ -120,13 +123,24 @@ class TestHttpsCheckServerLocation(unittest.TestCase):
             hostname="example.com", port=9443
         )
 
+    @parametrize(
+        ("port", "protocol"),
+        [
+            param(80, "http", id="http"),
+            param(443, "https", id="https"),
+        ],
+    )
     @patch("pshtt.pshtt.ServerConnectivityTester")
     @patch("pshtt.pshtt.ServerNetworkLocationViaDirectConnection")
-    def test_https_check_defaults_to_port_443(
-        self, mock_server_network_location, mock_server_connectivity_tester
+    def test_https_check_default_ports(
+        self,
+        mock_server_network_location,
+        mock_server_connectivity_tester,
+        port,
+        protocol,
     ):
-        """Default to port 443 when endpoint URL has no explicit port."""
-        endpoint = Endpoint("https", "root", "example.com")
+        """Default to expected default port when endpoint URL has no explicit port."""
+        endpoint = Endpoint(protocol, "root", "example.com")
 
         server_location = MagicMock()
         server_location.ip_address = "127.0.0.1"
@@ -146,34 +160,5 @@ class TestHttpsCheckServerLocation(unittest.TestCase):
             https_check(endpoint)
 
         mock_server_network_location.with_ip_address_lookup.assert_called_once_with(
-            hostname="example.com", port=443
-        )
-
-    @patch("pshtt.pshtt.ServerConnectivityTester")
-    @patch("pshtt.pshtt.ServerNetworkLocationViaDirectConnection")
-    def test_http_check_defaults_to_port_80(
-        self, mock_server_network_location, mock_server_connectivity_tester
-    ):
-        """Default to port 80 when an http endpoint URL has no explicit port."""
-        endpoint = Endpoint("http", "root", "example.com")
-
-        server_location = MagicMock()
-        server_location.ip_address = "127.0.0.1"
-        mock_server_network_location.with_ip_address_lookup.return_value = (
-            server_location
-        )
-
-        tester = MagicMock()
-        tester.perform.side_effect = RuntimeError("stop after checking location args")
-        mock_server_connectivity_tester.return_value = tester
-
-        # We stop the scan early by raising from perform(); https_check catches
-        # that and logs it via logging.exception, which would otherwise dump a
-        # traceback into the test output and look like a failure. Capture the
-        # expected error log so the output stays clean.
-        with self.assertLogs(level="ERROR"):
-            https_check(endpoint)
-
-        mock_server_network_location.with_ip_address_lookup.assert_called_once_with(
-            hostname="example.com", port=80
+            hostname="example.com", port=port
         )


### PR DESCRIPTION
Follow-up to #267. @dav3r noted that #267 also added the `http` -> port 80 default but only the port 443 and explicit-port cases had tests, and it auto-merged before that could be addressed. This adds `test_http_check_defaults_to_port_80` to cover the remaining branch.

It mirrors the existing `test_https_check_defaults_to_port_443` test, just with an http endpoint and port 80.

Note: I couldn't run the suite locally (sslyze's nassl native lib won't load on my macOS), but I verified the logic directly: `Endpoint("http", "root", "example.com").url` is `http://example.com`, and the port parse in `https_check` returns 80 for an http URL with no explicit port. CI should exercise the full test on Linux like its siblings.