### PR TITLE
[Issue #181] Compare certificate expiration timestamps in UTC

### DIFF
--- a/src/pshtt/_version.py
+++ b/src/pshtt/_version.py
@@ -1,3 +1,3 @@
 """This file defines the version of this module."""
 
-__version__ = "0.7.4"
+__version__ = "0.7.5"

--- a/src/pshtt/pshtt.py
+++ b/src/pshtt/pshtt.py
@@ -663,9 +663,7 @@ def certificate_is_expired(cert, now_utc=None):
                 tzinfo=datetime.timezone.utc
             )
         else:
-            not_valid_after_utc = not_valid_after_utc.astimezone(
-                datetime.timezone.utc
-            )
+            not_valid_after_utc = not_valid_after_utc.astimezone(datetime.timezone.utc)
 
     return not_valid_after_utc < now_utc
 

--- a/src/pshtt/pshtt.py
+++ b/src/pshtt/pshtt.py
@@ -650,6 +650,26 @@ def hsts_check(endpoint):
         return
 
 
+def certificate_is_expired(cert, now_utc=None):
+    """Determine whether a certificate is expired using UTC timestamps."""
+    if now_utc is None:
+        now_utc = datetime.datetime.now(datetime.timezone.utc)
+
+    not_valid_after_utc = getattr(cert, "not_valid_after_utc", None)
+    if not_valid_after_utc is None:
+        not_valid_after_utc = cert.not_valid_after
+        if not_valid_after_utc.tzinfo is None:
+            not_valid_after_utc = not_valid_after_utc.replace(
+                tzinfo=datetime.timezone.utc
+            )
+        else:
+            not_valid_after_utc = not_valid_after_utc.astimezone(
+                datetime.timezone.utc
+            )
+
+    return not_valid_after_utc < now_utc
+
+
 def https_check(endpoint):
     """Use sslyze to figure out the reason an endpoint failed to verify."""
     utils.debug("sslyzing %s...", endpoint.url)
@@ -770,6 +790,7 @@ def https_check(endpoint):
         endpoint.https_self_signed_cert = False
         endpoint.https_bad_chain = False
         endpoint.https_bad_hostname = False
+        now_utc = datetime.datetime.now(datetime.timezone.utc)
 
         # Default trust to False until proven True
         public_trust = True
@@ -793,7 +814,7 @@ def https_check(endpoint):
                     leaf_cert = cert_chain[0]
 
                     # Check for leaf certificate expiration/self-signature.
-                    if leaf_cert.not_valid_after < datetime.datetime.now():
+                    if certificate_is_expired(leaf_cert, now_utc):
                         endpoint.https_expired_cert = True
 
                     # Check to see if the cert is self-signed
@@ -811,7 +832,7 @@ def https_check(endpoint):
                     # because sslyze doesn't have enough granularity
                     for cert in cert_chain[:-1]:
                         # Check for certificate expiration
-                        if cert.not_valid_after < datetime.datetime.now():
+                        if certificate_is_expired(cert, now_utc):
                             endpoint.https_bad_chain = True
 
                         # Check to see if the cert is self-signed

--- a/src/pshtt/pshtt.py
+++ b/src/pshtt/pshtt.py
@@ -665,7 +665,7 @@ def certificate_is_expired(cert, now_utc=None):
         else:
             not_valid_after_utc = not_valid_after_utc.astimezone(datetime.timezone.utc)
 
-    return not_valid_after_utc < now_utc
+    return not_valid_after_utc <= now_utc
 
 
 def https_check(endpoint):

--- a/src/pshtt/pshtt.py
+++ b/src/pshtt/pshtt.py
@@ -658,12 +658,13 @@ def certificate_is_expired(cert, now_utc=None):
     not_valid_after_utc = getattr(cert, "not_valid_after_utc", None)
     if not_valid_after_utc is None:
         not_valid_after_utc = cert.not_valid_after
-        if not_valid_after_utc.tzinfo is None:
-            not_valid_after_utc = not_valid_after_utc.replace(
-                tzinfo=datetime.timezone.utc
-            )
-        else:
-            not_valid_after_utc = not_valid_after_utc.astimezone(datetime.timezone.utc)
+
+    if not_valid_after_utc.tzinfo is None:
+        # Naive timestamp
+        not_valid_after_utc = not_valid_after_utc.replace(tzinfo=datetime.timezone.utc)
+    else:
+        # TZ-aware timestamp
+        not_valid_after_utc = not_valid_after_utc.astimezone(datetime.timezone.utc)
 
     return not_valid_after_utc <= now_utc
 

--- a/tests/test_pshtt.py
+++ b/tests/test_pshtt.py
@@ -165,25 +165,63 @@ class TestHttpsCheckServerLocation(ParametrizedTestCase):
         )
 
 
-class TestCertificateExpiry(unittest.TestCase):
+class TestCertificateExpiry(ParametrizedTestCase):
     """Test certificate expiration logic uses UTC-aware comparisons."""
 
-    def test_naive_not_valid_after_is_treated_as_utc(self):
-        """A naive timestamp should be treated as UTC instead of local time."""
+    @parametrize(
+        "not_valid_after",
+        [
+            param(
+                datetime.datetime(2026, 1, 1, 12, 0, 0, tzinfo=datetime.timezone.utc),
+                id="timezone_aware",
+            ),
+            param(
+                datetime.datetime(
+                    2026,
+                    1,
+                    1,
+                    12,
+                    0,
+                    0,
+                ),
+                id="naive",
+            ),
+        ],
+    )
+    def test_not_valid_after_utc_unavailable(self, not_valid_after):
+        """Use not_valid_after if not_valid_after_utc is not available."""
         cert = MagicMock()
         cert.not_valid_after_utc = None
-        cert.not_valid_after = datetime.datetime(2026, 1, 1, 12, 0, 0)
+        cert.not_valid_after = not_valid_after
 
         now_utc = datetime.datetime(2026, 1, 1, 11, 0, 0, tzinfo=datetime.timezone.utc)
 
         self.assertFalse(certificate_is_expired(cert, now_utc))
 
-    def test_prefers_aware_not_valid_after_utc_when_available(self):
+    @parametrize(
+        "not_valid_after_utc",
+        [
+            param(
+                datetime.datetime(2026, 1, 1, 10, 0, 0, tzinfo=datetime.timezone.utc),
+                id="timezone_aware",
+            ),
+            param(
+                datetime.datetime(
+                    2026,
+                    1,
+                    1,
+                    10,
+                    0,
+                    0,
+                ),
+                id="naive",
+            ),
+        ],
+    )
+    def test_not_valid_after_utc_available(self, not_valid_after_utc):
         """Use not_valid_after_utc when cryptography exposes it."""
         cert = MagicMock()
-        cert.not_valid_after_utc = datetime.datetime(
-            2026, 1, 1, 10, 0, 0, tzinfo=datetime.timezone.utc
-        )
+        cert.not_valid_after_utc = not_valid_after_utc
 
         now_utc = datetime.datetime(2026, 1, 1, 11, 0, 0, tzinfo=datetime.timezone.utc)
 

--- a/tests/test_pshtt.py
+++ b/tests/test_pshtt.py
@@ -1,6 +1,7 @@
 """Test the core functionality of the library."""
 
 # Standard Python Libraries
+import datetime
 import unittest
 from unittest.mock import MagicMock, patch
 
@@ -9,7 +10,7 @@ from unittest_parametrize import ParametrizedTestCase, param, parametrize
 
 # cisagov Libraries
 from pshtt.models import Domain, Endpoint
-from pshtt.pshtt import https_check, is_live
+from pshtt.pshtt import certificate_is_expired, https_check, is_live
 
 
 class TestLiveliness(unittest.TestCase):
@@ -162,3 +163,28 @@ class TestHttpsCheckServerLocation(ParametrizedTestCase):
         mock_server_network_location.with_ip_address_lookup.assert_called_once_with(
             hostname="example.com", port=port
         )
+
+
+class TestCertificateExpiry(unittest.TestCase):
+    """Test certificate expiration logic uses UTC-aware comparisons."""
+
+    def test_naive_not_valid_after_is_treated_as_utc(self):
+        """A naive timestamp should be treated as UTC instead of local time."""
+        cert = MagicMock()
+        cert.not_valid_after_utc = None
+        cert.not_valid_after = datetime.datetime(2026, 1, 1, 12, 0, 0)
+
+        now_utc = datetime.datetime(2026, 1, 1, 11, 0, 0, tzinfo=datetime.timezone.utc)
+
+        self.assertFalse(certificate_is_expired(cert, now_utc))
+
+    def test_prefers_aware_not_valid_after_utc_when_available(self):
+        """Use not_valid_after_utc when cryptography exposes it."""
+        cert = MagicMock()
+        cert.not_valid_after_utc = datetime.datetime(
+            2026, 1, 1, 10, 0, 0, tzinfo=datetime.timezone.utc
+        )
+
+        now_utc = datetime.datetime(2026, 1, 1, 11, 0, 0, tzinfo=datetime.timezone.utc)
+
+        self.assertTrue(certificate_is_expired(cert, now_utc))


### PR DESCRIPTION
Fixes #181

I tracked this down to how expiration is compared in `https_check`: we compare certificate timestamps against local naive time, while SSLyze data is UTC-based. That can drift by timezone and produce inconsistent expired/not-expired results.

This change adds a small helper (`certificate_is_expired`) and uses one UTC `now` value for both leaf and chain certificate checks. It prefers `not_valid_after_utc` when available and falls back to treating naive timestamps as UTC for older certificate objects.

I also added unit coverage for both paths in `tests/test_pshtt.py`.

What I ran locally:
- `python3 -m py_compile src/pshtt/pshtt.py tests/test_pshtt.py`
- focused runtime assertions for `certificate_is_expired` (UTC-aware and naive fallback cases)

I could not run `pytest` on this macOS environment because `sslyze` pulls `nassl` and fails to import with `_SSLv2_method` missing. So I validated the helper behavior directly and left the new unit tests for CI.