### PR TITLE
fix: coerce is_strictly_forces_https return value to bool

### DIFF
--- a/src/pshtt/_version.py
+++ b/src/pshtt/_version.py
@@ -1,3 +1,3 @@
 """This file defines the version of this module."""
 
-__version__ = "0.7.5"
+__version__ = "0.7.6"

--- a/src/pshtt/pshtt.py
+++ b/src/pshtt/pshtt.py
@@ -1274,9 +1274,9 @@ def is_strictly_forces_https(domain):
     )
 
     def down_or_redirects(endpoint):
-        return not endpoint.live or endpoint.redirect_immediately_to_https
+        return (not endpoint.live) or bool(endpoint.redirect_immediately_to_https)
 
-    https_somewhere = https.live or httpswww.live
+    https_somewhere = bool(https.live or httpswww.live)
     all_http_unused = down_or_redirects(http) and down_or_redirects(httpwww)
 
     return https_somewhere and all_http_unused

--- a/tests/test_pshtt.py
+++ b/tests/test_pshtt.py
@@ -10,7 +10,12 @@ from unittest_parametrize import ParametrizedTestCase, param, parametrize
 
 # cisagov Libraries
 from pshtt.models import Domain, Endpoint
-from pshtt.pshtt import certificate_is_expired, https_check, is_live
+from pshtt.pshtt import (
+    certificate_is_expired,
+    https_check,
+    is_live,
+    is_strictly_forces_https,
+)
 
 
 class TestLiveliness(unittest.TestCase):
@@ -226,3 +231,54 @@ class TestCertificateExpiry(ParametrizedTestCase):
         now_utc = datetime.datetime(2026, 1, 1, 11, 0, 0, tzinfo=datetime.timezone.utc)
 
         self.assertTrue(certificate_is_expired(cert, now_utc))
+
+
+class TestStrictlyForcesHttps(unittest.TestCase):
+    """Test is_strictly_forces_https always returns a bool, never None.
+
+    When an endpoint is live but redirect_immediately_to_https has not been
+    determined yet (its default is None), the inner down_or_redirects helper
+    formerly evaluated ``False or None`` which Python propagates as None.
+    That None then bubbled up through the ``and`` chain so the public field
+    "Strictly Forces HTTPS" was reported as null in JSON output.  See #176.
+    """
+
+    def setUp(self):
+        """Set up a domain with fresh endpoints."""
+        base_domain = "example.com"
+        self.domain = Domain(base_domain)
+        self.domain.http = Endpoint("http", "root", base_domain)
+        self.domain.httpwww = Endpoint("http", "www", base_domain)
+        self.domain.https = Endpoint("https", "root", base_domain)
+        self.domain.httpswww = Endpoint("https", "www", base_domain)
+
+    def test_result_is_bool_when_http_live_and_redirect_unset(self):
+        """Return False (not None) when HTTP is live with no redirect configured."""
+        self.domain.https.live = True
+        self.domain.http.live = True
+        # redirect_immediately_to_https stays at its default value of None
+
+        result = is_strictly_forces_https(self.domain)
+
+        self.assertIsInstance(result, bool, "is_strictly_forces_https must return bool")
+        self.assertFalse(result)
+
+    def test_result_is_bool_when_all_endpoints_none(self):
+        """Return False (not None) when all endpoint attributes are still None."""
+        result = is_strictly_forces_https(self.domain)
+
+        self.assertIsInstance(result, bool, "is_strictly_forces_https must return bool")
+        self.assertFalse(result)
+
+    def test_strictly_forces_when_http_endpoints_redirect_to_https(self):
+        """Return True when HTTPS is live and HTTP endpoints redirect to HTTPS."""
+        self.domain.https.live = True
+        self.domain.http.live = True
+        self.domain.http.redirect_immediately_to_https = True
+        self.domain.httpwww.live = True
+        self.domain.httpwww.redirect_immediately_to_https = True
+
+        result = is_strictly_forces_https(self.domain)
+
+        self.assertIsInstance(result, bool)
+        self.assertTrue(result)


### PR DESCRIPTION
Fixes #176.

## Problem

`is_strictly_forces_https` could return `None` instead of `True`/`False`, which caused the "Strictly Forces HTTPS" JSON field to be `null` for some domains.

The root cause was in the `down_or_redirects` inner helper:

```python
# before
def down_or_redirects(endpoint):
    return not endpoint.live or endpoint.redirect_immediately_to_https
```

`redirect_immediately_to_https` defaults to `None` in `models.py` (line 58). When `endpoint.live` is `True`, Python evaluates `False or None` as `None`. That `None` then propagates through the `and` chain on line 1280, so the final return value is `None` rather than a bool.

## Fix

Wrap the attribute in `bool()` in the helper, and apply the same treatment to `https_somewhere`:

```python
def down_or_redirects(endpoint):
    return (not endpoint.live) or bool(endpoint.redirect_immediately_to_https)

https_somewhere = bool(https.live or httpswww.live)
```

Both `bool(None)` → `False` and `bool(True)` → `True`, so the semantics are unchanged for any non-None value.

## Tests

Adds `TestStrictlyForcesHttps` with three cases:
- All endpoints at default (None) state → returns `False`, not `None`
- HTTPS live, HTTP live with `redirect_immediately_to_https=None` → returns `False`, not `None`
- HTTPS live, HTTP endpoints both redirecting to HTTPS → returns `True`